### PR TITLE
Fix class member fields iterators

### DIFF
--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -1662,7 +1662,9 @@ namespace MRBind::pb11
                     +[](T &target)
                     {
                         return pybind11::make_iterator<pybind11::return_value_policy::copy>(begin(target), end(target));
-                    }
+                    },
+                    // Looks like without `keep_alive` copied iterator might spoil out 
+                    pybind11::keep_alive<0, 1>()
                 );
             }
         }

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -1663,7 +1663,7 @@ namespace MRBind::pb11
                     {
                         return pybind11::make_iterator<pybind11::return_value_policy::copy>(begin(target), end(target));
                     },
-                    // Looks like without `keep_alive` copied iterator might spoil out 
+                    // This one IS important, because the policy isn't `reference_internal`. Omitting this causes dangling in some cases, when the container is a temporary.
                     pybind11::keep_alive<0, 1>()
                 );
             }


### PR DESCRIPTION
This code produces segfault before
```py
from meshlib import mrmeshpy as mm
mesh = mm.makeCube()
for f in mesh.topology.getValidFaces():
    print(f)
``` 

After this fix it seems to work properly