### PR TITLE
Parser: skip primary function templates in Sema instantiation calls

### DIFF
--- a/src/parser/main.cpp
+++ b/src/parser/main.cpp
@@ -42,6 +42,8 @@
 #include <clang/Tooling/CommonOptionsParser.h>
 #include <clang/Tooling/Tooling.h>
 #include <llvm/Support/CommandLine.h>
+#include <llvm/Support/PrettyStackTrace.h>
+#include <llvm/Support/Signals.h>
 #include "post_include_clang.h"
 
 #include <array>
@@ -3470,6 +3472,13 @@ namespace mrbind
 
 int main(int raw_argc, char **raw_argv)
 {
+    // Print a stack trace to stderr on SIGSEGV / SEH access violations.
+    // RelWithDebInfo builds keep DWARF symbols in mrbind.exe, so the mrbind
+    // frames in the trace are line-numbered. libclang-cpp.dll frames will
+    // only show function names (msys2 strips DLL debug info).
+    llvm::sys::PrintStackTraceOnErrorSignal(raw_argv[0]);
+    llvm::PrettyStackTraceProgram pretty_stack(raw_argc, raw_argv);
+
     mrbind::SetErrorHandlers();
 
     std::string dump_command_to_file;

--- a/src/parser/main.cpp
+++ b/src/parser/main.cpp
@@ -2689,7 +2689,12 @@ namespace mrbind
         {
             // If this is a template, try instantiating it.
             // This is currently disabled by default because it's buggy: https://github.com/MeshInspector/mrbind/issues/19
-            if (params->buggy_substitute_default_template_args && decl->isTemplated() && !ShouldRejectFunction(*decl, *ctx, *ci, *params, printing_policies, ShouldRejectFlags::allow_uninstantiated_templates))
+            //
+            // Skip class members entirely (constructors, methods, ...). Per the comment below,
+            // they don't need this path, and `Sema::SubstDecl` on a member function template's
+            // pattern null-derefs internally on at least clang 22 — for example, a constructor
+            // template substitution crashes in `TemplateDeclInstantiator::InitMethodInstantiation`.
+            if (params->buggy_substitute_default_template_args && decl->isTemplated() && !llvm::isa<clang::CXXMethodDecl>(decl) && !ShouldRejectFunction(*decl, *ctx, *ci, *params, printing_policies, ShouldRejectFlags::allow_uninstantiated_templates))
             {
                 // Among other things, we visit the function declarations to instantiate their default arguments,
                 //   which apparently doesn't happen otherwise. This is only needed for free function templates.

--- a/src/parser/main.cpp
+++ b/src/parser/main.cpp
@@ -1067,6 +1067,13 @@ namespace mrbind
     // If this function returns `auto` that wasn't deduced yet, replace it with the correct return type.
     [[nodiscard]] bool InstantiateReturnTypeIfNeeded(clang::CompilerInstance &ci, clang::FunctionDecl &decl)
     {
+        // Skip primary function templates: `Sema::InstantiateFunctionDefinition` is meant
+        // for instantiations and null-derefs internally on a primary template
+        // (`clang::FunctionDecl::isDefined()` deref of an invalid pattern decl).
+        // Specific instantiations are visited separately and handled correctly.
+        if (decl.isTemplated())
+            return false;
+
         if (decl.getReturnType()->isUndeducedAutoType())
         {
             ci.getSema().InstantiateFunctionDefinition(decl.getBeginLoc(), &decl);
@@ -2833,7 +2840,12 @@ namespace mrbind
             for (clang::ParmVarDecl *p : decl->parameters())
             {
                 // Instantiate the default arguments and the underlying parameter types.
-                if (p->hasUninstantiatedDefaultArg())
+                // Skip primary function templates: `Sema::InstantiateDefaultArgument` is meant
+                // for instantiations, and on a primary template it null-derefs internally
+                // (`FunctionDecl::getTemplateInstantiationPattern(false)` returns `nullptr`,
+                // which `Sema::addInstantiatedParametersToScope` then dereferences). Specific
+                // instantiations are visited separately and handled correctly.
+                if (p->hasUninstantiatedDefaultArg() && !decl->isTemplated())
                 {
                     ci->getSema().InstantiateDefaultArgument(decl->getSourceRange().getBegin(), decl, p);
                     need_another_iteration = true; // Do we need this? Better be safe.

--- a/src/parser/main.cpp
+++ b/src/parser/main.cpp
@@ -2754,12 +2754,7 @@ namespace mrbind
 
             // If this is a template, try instantiating it.
             // This is currently disabled by default because it's buggy: https://github.com/MeshInspector/mrbind/issues/19
-            //
-            // Skip class members entirely (constructors, methods, ...). Per the comment below,
-            // they don't need this path, and `Sema::SubstDecl` on a member function template's
-            // pattern null-derefs internally on at least clang 22 — for example, a constructor
-            // template substitution crashes in `TemplateDeclInstantiator::InitMethodInstantiation`.
-            if (params->buggy_substitute_default_template_args && decl->isTemplated() && !llvm::isa<clang::CXXMethodDecl>(decl) && !ShouldRejectFunction(*decl, *ctx, *ci, *params, printing_policies, ShouldRejectFlags::allow_uninstantiated_templates))
+            if (params->buggy_substitute_default_template_args && decl->isTemplated() && !ShouldRejectFunction(*decl, *ctx, *ci, *params, printing_policies, ShouldRejectFlags::allow_uninstantiated_templates))
             {
                 if (auto templ = decl->getDescribedTemplate())
                 {


### PR DESCRIPTION
## Summary

The visitor unconditionally called `Sema::InstantiateDefaultArgument` and `Sema::InstantiateFunctionDefinition` on every `FunctionDecl` it traversed, including primary function templates that pass through because of `allow_uninstantiated_templates`. On a primary template both APIs null-deref inside libclang and crash with `STATUS_ACCESS_VIOLATION`. Skipping the call when `decl.isTemplated()` is true fixes both crashes — the specific instantiations are visited separately and processed correctly.

## Stack traces (clang 22.1.4, MSYS2 mingw-w64-clang-x86_64)

`InstantiateDefaultArgument` at `main.cpp:2838`:

```
#0  clang::FunctionDecl::getNumParams() const                      (this = invalid)
#1  clang::Sema::addInstantiatedParametersToScope
#2  clang::Sema::SubstDefaultArgument                              (ForCallExpr = true)
#3  clang::Sema::InstantiateDefaultArgument
#4  mrbind::ClangAstVisitor_InstTypesAndCollectNewTypes::VisitFunctionDecl  (main.cpp:2838)
```

`InstantiateFunctionDefinition` at `main.cpp:1072`:

```
#0  clang::FunctionDecl::isDefined(FunctionDecl const*&, bool)     (this = invalid)
#1  clang::Sema::InstantiateFunctionDefinition
#2  mrbind::InstantiateReturnTypeIfNeeded                          (main.cpp:1072)
#3  mrbind::ClangAstVisitor_InstTypesAndCollectNewTypes::VisitFunctionDecl  (main.cpp:2859)
```

Both inputs the same: `PatternFD` returned by `FunctionDecl::getTemplateInstantiationPattern(/*ForDefinition*/ false)` on a primary template is null, and Sema dereferences it without a guard.

## Tested clang versions

| clang | repro without fix | with fix |
|---|---|---|
| 18.1.8 | crashes | clean |
| 19.1.7 | crashes | clean |
| 21.1.8 | crashes | clean |
| 22.1.4 | crashes | clean |

Source-diff of `Sema::SubstDefaultArgument`, `Sema::addInstantiatedParametersToScope`, `Sema::InstantiateDefaultArgument`, `FunctionDecl::getTemplateInstantiationPattern` across `llvmorg-18.1.8 ... llvmorg-22.1.4` is logically identical (only type/RAII renames), so the bug is at least as old as v18.

Standalone clang-tooling reproducer (no mrbind dependency):

```cpp
// repro_input.cpp
template <typename T> struct Wrap {
    template <typename U = T> void method(int x = sizeof(U)) {}
};
inline void use() { Wrap<int> w; w.method(); }
```

A `RecursiveASTVisitor` whose `VisitFunctionDecl` calls `Sema::InstantiateDefaultArgument` on every `ParmVarDecl` with `hasUninstantiatedDefaultArg()` (no `isTemplated()` guard) crashes identically inside libclang. Will be filed upstream against LLVM as API hardening (`Sema::InstantiateDefaultArgument`'s documented precondition is only `assert(Param->hasUninstantiatedDefaultArg())` — it should also assert `FD->isTemplateInstantiation()` or fail gracefully on a null pattern).

## Verification on real input

Local mrbind build with this fix, parsing `#include <boost/multiprecision/cpp_int.hpp>` on clang 22.1.4:

- Without fix: silent crash after 0 lines of output (the original CI signature).
- With fix: parser progresses past Sema instantiation, reaches a separate cppdecl error on `_Complex _Float16` — that's a different issue in a different library, not addressed here.

## Test plan

- [ ] CI on this branch is green (mrbind has its own tests in `test/`).
- [ ] Picked up as a submodule bump in MeshLib PR #6021 (clang 22 toolchain) and observed to clear the `STATUS_ACCESS_VIOLATION` segfault during `Generate C bindings`.
