### PR TITLE
Add MRBIND_LINK_CLANG_CPP_DYLIB opt-in for smaller mrbind on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,17 +85,28 @@ Smaller binary, but the dylibs must be present at the same paths at runtime."
         # (that we know of) are Arch and Rocky. The `LLVM` part is only needed
         # on Rocky.
         #
-        # `$<LINK_ONLY:...>` keeps the targets on the link line but drops their
-        # INTERFACE_INCLUDE_DIRECTORIES. Homebrew's clang-cpp exports
-        # `/opt/homebrew/opt/llvm@N/include` there, which -- if propagated --
-        # comes ahead of libc++'s own header dir and breaks `<cstddef>`'s
-        # include chain at compile time. mrbind already explicitly adds the
-        # required include paths above (`LLVM_INCLUDE_DIR`/`CLANG_INCLUDE_DIR`),
-        # so dropping the link-target propagation is safe everywhere.
-        target_link_libraries(mrbind PRIVATE
-            $<LINK_ONLY:clang-cpp>
-            $<LINK_ONLY:LLVM>
-            $<LINK_ONLY:LLVMSupport>)
+        # Resolve to absolute library paths via `find_library` instead of using
+        # the imported targets `clang-cpp` / `LLVM` / `LLVMSupport` directly.
+        # Linking through the imported targets propagates their
+        # INTERFACE_INCLUDE_DIRECTORIES (and possibly INTERFACE_COMPILE_OPTIONS),
+        # which on Homebrew's `llvm@N` adds `/opt/homebrew/opt/llvm@N/include`
+        # to mrbind's compile line and breaks libc++'s `<cstddef>` include
+        # chain. Linking by absolute path adds the libs to the link line
+        # without any usage-requirement propagation. mrbind already explicitly
+        # adds the include paths it needs above
+        # (`LLVM_INCLUDE_DIR`/`CLANG_INCLUDE_DIR`).
+        find_library(MRBIND_CLANG_CPP_LIB NAMES clang-cpp HINTS ${LLVM_LIBRARY_DIRS} REQUIRED)
+        target_link_libraries(mrbind PRIVATE ${MRBIND_CLANG_CPP_LIB})
+
+        find_library(MRBIND_LLVM_LIB NAMES LLVM HINTS ${LLVM_LIBRARY_DIRS})
+        if (MRBIND_LLVM_LIB)
+            target_link_libraries(mrbind PRIVATE ${MRBIND_LLVM_LIB})
+        endif()
+
+        find_library(MRBIND_LLVM_SUPPORT_LIB NAMES LLVMSupport HINTS ${LLVM_LIBRARY_DIRS})
+        if (MRBIND_LLVM_SUPPORT_LIB)
+            target_link_libraries(mrbind PRIVATE ${MRBIND_LLVM_SUPPORT_LIB})
+        endif()
     else()
         target_link_libraries(mrbind PRIVATE clangTooling)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,14 +65,28 @@ if(MRBIND_BUILD_PARSER)
 
     target_include_directories(mrbind PRIVATE ${LLVM_INCLUDE_DIR} ${CLANG_INCLUDE_DIR})
 
-    if (TARGET clangTooling)
-        target_link_libraries(mrbind PRIVATE clangTooling)
-    else()
-        # The only platforms where this branch is used (that I know of) are Arch and Rocky.
-        # The `LLVM` part is only needed on Rocky.
-        # Trying this on e.g. Ubuntu causes the following runtime error when you run the resulting application:
-        #   LLVM ERROR: inconsistency in registered CommandLine options
+    # Opt-in: link against `libclang-cpp.dylib` + `libLLVM.dylib` instead of
+    # statically pulling in `clangTooling`. The dynamic path produces a much
+    # smaller `mrbind` binary (single shared lib resolved at runtime, vs. the
+    # entire clang/LLVM frontend statically linked). Useful for CI caches.
+    #
+    # We don't make it the default because on apt-clang/Ubuntu this branch
+    # caused `LLVM ERROR: inconsistency in registered CommandLine options` at
+    # runtime (duplicate `cl::opt` registrations between libclang-cpp.so and
+    # the granular libs that still slip into the link line). Homebrew's
+    # `llvm@N` on macOS is built with `LLVM_LINK_LLVM_DYLIB=ON` and doesn't
+    # exhibit that problem, so enabling this for Apple is safe.
+    option(MRBIND_LINK_CLANG_CPP_DYLIB
+        "Link mrbind against libclang-cpp + libLLVM dylibs instead of clangTooling. \
+Smaller binary, but the dylibs must be present at the same paths at runtime."
+        OFF)
+    if (MRBIND_LINK_CLANG_CPP_DYLIB OR NOT TARGET clangTooling)
+        # The only platforms where the `NOT TARGET clangTooling` branch is hit
+        # (that we know of) are Arch and Rocky. The `LLVM` part is only needed
+        # on Rocky.
         target_link_libraries(mrbind PRIVATE clang-cpp LLVM LLVMSupport)
+    else()
+        target_link_libraries(mrbind PRIVATE clangTooling)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,18 @@ Smaller binary, but the dylibs must be present at the same paths at runtime."
         # The only platforms where the `NOT TARGET clangTooling` branch is hit
         # (that we know of) are Arch and Rocky. The `LLVM` part is only needed
         # on Rocky.
-        target_link_libraries(mrbind PRIVATE clang-cpp LLVM LLVMSupport)
+        #
+        # `$<LINK_ONLY:...>` keeps the targets on the link line but drops their
+        # INTERFACE_INCLUDE_DIRECTORIES. Homebrew's clang-cpp exports
+        # `/opt/homebrew/opt/llvm@N/include` there, which -- if propagated --
+        # comes ahead of libc++'s own header dir and breaks `<cstddef>`'s
+        # include chain at compile time. mrbind already explicitly adds the
+        # required include paths above (`LLVM_INCLUDE_DIR`/`CLANG_INCLUDE_DIR`),
+        # so dropping the link-target propagation is safe everywhere.
+        target_link_libraries(mrbind PRIVATE
+            $<LINK_ONLY:clang-cpp>
+            $<LINK_ONLY:LLVM>
+            $<LINK_ONLY:LLVMSupport>)
     else()
         target_link_libraries(mrbind PRIVATE clangTooling)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,36 +65,32 @@ if(MRBIND_BUILD_PARSER)
 
     target_include_directories(mrbind PRIVATE ${LLVM_INCLUDE_DIR} ${CLANG_INCLUDE_DIR})
 
-    # Opt-in: link against `libclang-cpp.dylib` + `libLLVM.dylib` instead of
-    # statically pulling in `clangTooling`. The dynamic path produces a much
-    # smaller `mrbind` binary (single shared lib resolved at runtime, vs. the
-    # entire clang/LLVM frontend statically linked). Useful for CI caches.
+    # Opt-in: link against `libclang-cpp` + `libLLVM` dylibs instead of
+    # statically pulling in `clangTooling`. Produces a much smaller `mrbind`
+    # binary (single shared lib resolved at runtime, vs. the entire clang/LLVM
+    # frontend statically linked). Useful for CI caches.
     #
-    # We don't make it the default because on apt-clang/Ubuntu this branch
-    # caused `LLVM ERROR: inconsistency in registered CommandLine options` at
-    # runtime (duplicate `cl::opt` registrations between libclang-cpp.so and
+    # Default is OFF because on apt-clang/Ubuntu the dynamic path crashes at
+    # startup with `LLVM ERROR: inconsistency in registered CommandLine
+    # options` (duplicate `cl::opt` registrations between libclang-cpp.so and
     # the granular libs that still slip into the link line). Homebrew's
     # `llvm@N` on macOS is built with `LLVM_LINK_LLVM_DYLIB=ON` and doesn't
-    # exhibit that problem, so enabling this for Apple is safe.
+    # exhibit that problem, so callers on macOS can safely set this to ON.
     option(MRBIND_LINK_CLANG_CPP_DYLIB
         "Link mrbind against libclang-cpp + libLLVM dylibs instead of clangTooling. \
 Smaller binary, but the dylibs must be present at the same paths at runtime."
         OFF)
-    if (MRBIND_LINK_CLANG_CPP_DYLIB OR NOT TARGET clangTooling)
-        # The only platforms where the `NOT TARGET clangTooling` branch is hit
-        # (that we know of) are Arch and Rocky. The `LLVM` part is only needed
-        # on Rocky.
-        #
-        # Resolve to absolute library paths via `find_library` instead of using
-        # the imported targets `clang-cpp` / `LLVM` / `LLVMSupport` directly.
+    if (MRBIND_LINK_CLANG_CPP_DYLIB)
+        # Resolve to absolute library paths via `find_library` instead of
+        # using the imported targets `clang-cpp` / `LLVM` / `LLVMSupport`.
         # Linking through the imported targets propagates their
-        # INTERFACE_INCLUDE_DIRECTORIES (and possibly INTERFACE_COMPILE_OPTIONS),
-        # which on Homebrew's `llvm@N` adds `/opt/homebrew/opt/llvm@N/include`
-        # to mrbind's compile line and breaks libc++'s `<cstddef>` include
-        # chain. Linking by absolute path adds the libs to the link line
-        # without any usage-requirement propagation. mrbind already explicitly
-        # adds the include paths it needs above
-        # (`LLVM_INCLUDE_DIR`/`CLANG_INCLUDE_DIR`).
+        # INTERFACE_INCLUDE_DIRECTORIES (and possibly other usage
+        # requirements), which on Homebrew's `llvm@N` adds
+        # `/opt/homebrew/opt/llvm@N/include` to mrbind's compile line and
+        # breaks libc++'s `<cstddef>` include chain. Linking by absolute path
+        # adds the libs to the link line without any propagation. mrbind
+        # already explicitly adds the include paths it needs above via
+        # `LLVM_INCLUDE_DIR` / `CLANG_INCLUDE_DIR`.
         find_library(MRBIND_CLANG_CPP_LIB NAMES clang-cpp HINTS ${LLVM_LIBRARY_DIRS} REQUIRED)
         target_link_libraries(mrbind PRIVATE ${MRBIND_CLANG_CPP_LIB})
 
@@ -107,8 +103,14 @@ Smaller binary, but the dylibs must be present at the same paths at runtime."
         if (MRBIND_LLVM_SUPPORT_LIB)
             target_link_libraries(mrbind PRIVATE ${MRBIND_LLVM_SUPPORT_LIB})
         endif()
-    else()
+    elseif (TARGET clangTooling)
         target_link_libraries(mrbind PRIVATE clangTooling)
+    else()
+        # The only platforms where this branch is used (that I know of) are Arch and Rocky.
+        # The `LLVM` part is only needed on Rocky.
+        # Trying this on e.g. Ubuntu causes the following runtime error when you run the resulting application:
+        #   LLVM ERROR: inconsistency in registered CommandLine options
+        target_link_libraries(mrbind PRIVATE clang-cpp LLVM LLVMSupport)
     endif()
 endif()
 


### PR DESCRIPTION
## Why

`mrbind`'s parser binary is currently ~30 MiB stripped on macOS / Ubuntu / Windows-MSYS2 because it statically links the granular `clangTooling` / friends. On Rocky Linux it's ~5 MiB stripped because the local LLVM cmake config doesn't expose `clangTooling` and we fall through to the `clang-cpp + LLVM` (dynamic) branch.

For consumers caching `thirdparty/mrbind/build` across CI runs (e.g. [MeshLib/build-mrbind](https://github.com/MeshInspector/MeshLib/blob/master/.github/actions/build-mrbind/action.yml)), the per-platform cache footprint is ~12 MiB compressed where the static path is used vs ~2 MiB on Rocky. Across the matrix that's the difference between ~90 MiB and ~20 MiB of cache.

## What

Add a new CMake option, `MRBIND_LINK_CLANG_CPP_DYLIB`, off by default. When ON, link mrbind against `libclang-cpp` + `libLLVM` (single shared lib resolved at runtime) instead of `clangTooling`. The fallback for platforms where `clangTooling` isn't exposed (Arch, Rocky) is unchanged — they continue to take the dynamic path implicitly.

The OFF branch keeps the old `clangTooling` / `clang-cpp + LLVM + LLVMSupport` logic untouched. The ON branch is written separately and uses `find_library` to resolve to absolute library paths rather than linking through the imported targets `clang-cpp` / `LLVM` / `LLVMSupport` — see "find_library vs imported targets" below.

```cmake
option(MRBIND_LINK_CLANG_CPP_DYLIB
    "Link mrbind against libclang-cpp + libLLVM dylibs instead of clangTooling. \
Smaller binary, but the dylibs must be present at the same paths at runtime."
    OFF)
if (MRBIND_LINK_CLANG_CPP_DYLIB)
    find_library(MRBIND_CLANG_CPP_LIB NAMES clang-cpp HINTS ${LLVM_LIBRARY_DIRS} REQUIRED)
    target_link_libraries(mrbind PRIVATE ${MRBIND_CLANG_CPP_LIB})

    find_library(MRBIND_LLVM_LIB NAMES LLVM HINTS ${LLVM_LIBRARY_DIRS})
    if (MRBIND_LLVM_LIB)
        target_link_libraries(mrbind PRIVATE ${MRBIND_LLVM_LIB})
    endif()

    find_library(MRBIND_LLVM_SUPPORT_LIB NAMES LLVMSupport HINTS ${LLVM_LIBRARY_DIRS})
    if (MRBIND_LLVM_SUPPORT_LIB)
        target_link_libraries(mrbind PRIVATE ${MRBIND_LLVM_SUPPORT_LIB})
    endif()
elseif (TARGET clangTooling)
    target_link_libraries(mrbind PRIVATE clangTooling)
else()
    # Arch / Rocky fallback (LLVM only needed on Rocky)
    target_link_libraries(mrbind PRIVATE clang-cpp LLVM LLVMSupport)
endif()
```

## find_library vs imported targets

The naive shape `target_link_libraries(mrbind PRIVATE clang-cpp LLVM LLVMSupport)` linked through Clang's imported targets and propagated their `INTERFACE_INCLUDE_DIRECTORIES` into mrbind's compile commands. On Homebrew's `llvm@N` that includes `/opt/homebrew/opt/llvm@N/include`, which gets inserted *before* libc++'s wrapper headers and breaks the libc++ `<cstddef>` include chain (`<cstddef>` ends up pulling LLVM-bundled `<stddef.h>` instead of the libc++ wrapper).

`find_library` returns an absolute path, so passing that to `target_link_libraries` adds the lib to the link line without any usage-requirement propagation. mrbind already explicitly adds the include paths it needs above via `LLVM_INCLUDE_DIR` / `CLANG_INCLUDE_DIR`.

## Why off by default

The existing comment in the file documents that on apt-clang/Ubuntu, the dynamic path crashed at startup:

```
LLVM ERROR: inconsistency in registered CommandLine options
```

This is duplicate `cl::opt` registrations between `libclang-cpp.so` and the granular libs that still slip into the link line on Debian-family LLVM packaging. Default-off preserves the current safe behaviour for everyone.

## When to turn it on

Consumers who know their LLVM was built with `LLVM_LINK_LLVM_DYLIB=ON` (Homebrew's `llvm@N` on macOS is a confirmed case) can pass `-DMRBIND_LINK_CLANG_CPP_DYLIB=ON` to their cmake invocation. The resulting binary depends on `libclang-cpp.dylib` / `libLLVM.dylib` being resolvable at the same path at runtime, which is usually fine for CI but worth being explicit about.

## Test plan

- [x] **mrbind's own CI passes** — default-off path is unchanged, so this is a no-op for everyone not opting in.
- [x] **Downstream verified on MeshLib** — [MeshInspector/MeshLib#6101](https://github.com/MeshInspector/MeshLib/pull/6101) passes this flag from `install_mrbind_macos.sh` and goes green on all three macOS jobs (`x64 Release`, `arm64 Release`, `arm64 Debug`). Build MRBind, Generate C bindings, and Generate and build Python bindings all succeed; no `inconsistency in registered CommandLine options` and no libc++ `<cstddef>` failures.
- [x] **Cache footprint drops as predicted** — all three macOS runners (two GitHub-hosted, one self-hosted) drop from ~12–13 MiB to ~2 MiB compressed, matching Rocky's footprint.
