### PR TITLE
Fix std::hash<std::filesystem::path> polyfill clashing on libstdc++ 11.4+

### DIFF
--- a/src/common/polyfill/std_filesystem_path_hash.h
+++ b/src/common/polyfill/std_filesystem_path_hash.h
@@ -2,9 +2,13 @@
 
 #include <version>
 
-// Old libstdc++ didn't have `std::hash<std::filesystem::path>`, which was apparently added in a defect report.
-// GCC added it in this commit: https://github.com/gcc-mirror/gcc/commit/e3c5e8360b4e4799e1e2daf74282629248690f23
-#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12
+// Old libstdc++ didn't have `std::hash<std::filesystem::path>`, which was added by a defect report (LWG 3657):
+// https://github.com/gcc-mirror/gcc/commit/e3c5e8360b4e4799e1e2daf74282629248690f23
+// It shipped natively in GCC 12 and was backported only to the libstdc++ 11 branch, first appearing in the
+// GCC 11.4.0 release (`__GLIBCXX__ == 20230528`); the 9.x and 10.x branches and 11.0-11.3 never got it. So
+// define the polyfill only where the standard library still lacks the specialization -- otherwise it clashes
+// with the one libstdc++ already provides (e.g. on Ubuntu jammy, which now ships libstdc++ 11.4).
+#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12 && !(_GLIBCXX_RELEASE == 11 && __GLIBCXX__ >= 20230528)
 
 #include <cstddef>
 #include <filesystem>


### PR DESCRIPTION
## Problem

The `std::hash<std::filesystem::path>` polyfill in `src/common/polyfill/std_filesystem_path_hash.h` is guarded by:

```cpp
#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12
```

`std::hash<std::filesystem::path>` (LWG 3657) shipped natively in GCC 12, but it was **backported to the libstdc++ 11 branch in GCC 11.4.0**. On such a libstdc++ the polyfill redefines the specialization the standard library already provides, so any translation unit that includes this header fails with:

```
error: redefinition of 'hash<std::filesystem::path>'
note: previous definition is here   .../include/c++/11/bits/fs_path.h
```

This now bites on Ubuntu jammy (which ships libstdc++ 11.4) — e.g. building MRBind inside the `emscripten/emsdk:4.0.10` image (jammy-based) for MeshLib's C-bindings generation.

## Fix

Narrow the guard so the polyfill is defined only where libstdc++ genuinely lacks the specialization:

```cpp
#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12 && !(_GLIBCXX_RELEASE == 11 && __GLIBCXX__ >= 20230528)
```

`20230528` is the datestamp of GCC 11.4.0 (the first 11.x release with the backport).

## Verified against the libstdc++ sources

`std::hash<filesystem::path>` presence in `bits/fs_path.h`, checked per release tag:

| libstdc++ | `__GLIBCXX__` | hash present? | polyfill after fix |
|---|---|---|---|
| 9.5.0 | — | no | on |
| 10.5.0 | — | no | on |
| 11.2.0 / 11.3.0 | ≤ 20220421 | no | on |
| 11.4.0 | 20230528 | **yes** | off |
| 11.5.0 | 20240719 | yes | off |
| 12.1.0+ | — | yes (native) | off (`_GLIBCXX_RELEASE >= 12`) |

So the older toolchains that still need the polyfill (9.x, 10.x, 11.0–11.3 — e.g. RHEL gcc-toolset-11) keep it, while 11.4+ correctly defers to the standard library. Non-libstdc++ standard libraries are unaffected (`_GLIBCXX_RELEASE` undefined → guard is false).
