### PR TITLE
pybind11: fix MB_PB11_OFFSETOF compile error on GCC

### DIFF
--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -63,8 +63,19 @@
 #endif
 
 // Like `offsetof(...)`, but with dumb warnings disabled.
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__clang__)
 #define MB_PB11_OFFSETOF(...) _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"") offsetof(__VA_ARGS__) _Pragma("GCC diagnostic pop")
+#elif defined(__GNUC__)
+// Unlike Clang, GCC rejects `_Pragma` in an expression context (`'#pragma' is not allowed here`),
+// and this macro is used inside expressions. Wrap it in a statement expression so the diagnostic
+// pragmas sit at statement scope, while still keeping `-Winvalid-offsetof` suppressed.
+#define MB_PB11_OFFSETOF(...) __extension__ ({ \
+        _Pragma("GCC diagnostic push") \
+        _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"") \
+        auto _mb_pb11_offset = offsetof(__VA_ARGS__); \
+        _Pragma("GCC diagnostic pop") \
+        _mb_pb11_offset; \
+    })
 #else
 #define MB_PB11_OFFSETOF(...) offsetof(__VA_ARGS__)
 #endif

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -66,9 +66,7 @@
 #if defined(__clang__)
 #define MB_PB11_OFFSETOF(...) _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"") offsetof(__VA_ARGS__) _Pragma("GCC diagnostic pop")
 #elif defined(__GNUC__)
-// Unlike Clang, GCC rejects `_Pragma` in an expression context (`'#pragma' is not allowed here`),
-// and this macro is used inside expressions. Wrap it in a statement expression so the diagnostic
-// pragmas sit at statement scope, while still keeping `-Winvalid-offsetof` suppressed.
+// Unlike Clang, GCC rejects `_Pragma(...)` in the middle of expressions. Using statement expressions seems to help.
 #define MB_PB11_OFFSETOF(...) __extension__ ({ \
         _Pragma("GCC diagnostic push") \
         _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"") \


### PR DESCRIPTION
## Problem

Compiling the generated pybind11 bindings with **GCC** (rather than Clang) fails in `core.h`:

```
core.h:67: error: '#pragma' is not allowed here
core.h: error: no match for 'operator+' (operand type is '<lambda...>')
```

`MB_PB11_OFFSETOF` expands `_Pragma(...)` **inline in an expression** — it is used inside a lambda body:

```c
... +[](const pybind11::object &){ ...; return MB_PB11_OFFSETOF(_self, name_); } ...
```

Clang accepts `_Pragma` in expression context; GCC rejects it (`'#pragma' is not allowed here`). That in turn makes the enclosing lambda ill-formed, which cascades into the bogus `no match for 'operator+'` on the `+[]{...}` conversion.

## Fix

Keep Clang's existing inline form, and for GCC wrap the `offsetof` in a statement expression so the diagnostic pragmas sit at **statement** scope. The `-Winvalid-offsetof` suppression is preserved (dropping it would emit a warning for every bound non-standard-layout field).

This mirrors how the sibling macro `MB_PB11_NO_WARN_ON_DUPLICATE_BASE` (a few lines above) already special-cases `__clang__` versus everything else.

## Context

Needed by MeshInspector/MeshLib [#6270](https://github.com/MeshInspector/MeshLib/pull/6270), which builds the Python bindings with the same compiler as the main build (GCC on the GCC CI lanes) instead of always Clang.
