### PR TITLE
pybind11: bind member functions via a forwarding lambda (fixes MSVC C2440 on overloaded auto-returning members of class templates)

### DIFF
--- a/include/mrbind/helpers/rebind_container.h
+++ b/include/mrbind/helpers/rebind_container.h
@@ -29,6 +29,8 @@ namespace MRBind
 
     // NOTE: On Clang 18 and older those specializations require `-frelaxed-template-template-args` to function.
     // On MSVC they don't work at all! If we decide we need MSVC support, we'll need to rewrite those, and I have no idea how to make it generic,
+    // (MSVC's P0522 relaxed-template-template-matching gap in partial specializations, reported at
+    //  https://developercommunity.visualstudio.com/t/Partial-specialization-with-a-single-arg/11108062 )
     // especially because e.g. phmap does something very strange with its template parameters (e.g. I think strings use a different hasher?),
     // so it would need handwritten specializations, I think? Ugh.
 

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -3863,13 +3863,17 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
 
 // Produces the callable that binds a member function (see the NOTE in `..._method` below for why
 // this is a forwarding lambda rather than a `static_cast`ed pointer-to-member). `_pb11_C` is the
-// class being bound. Mirrors the friend-function lambda in `..._FUNC_PTR_OR_LAMBDA_cl` above, and
-// like it costs an extra move per argument.
-#define DETAIL_MB_PB11_METHOD_FUNC(static_, name_, const_, params_) MRBIND_CAT(DETAIL_MB_PB11_METHOD_FUNC_, static_)(name_, const_, params_)
-#define DETAIL_MB_PB11_METHOD_FUNC_(name_, const_, params_) \
-    +[](_pb11_C const_ &_pb11_self DETAIL_MB_PB11_MAKE_PARAM_DECLS_WITH_LEADING_COMMA(params_)) -> decltype(auto) {return _pb11_self.name_(DETAIL_MB_PB11_MAKE_PARAM_USES(params_));}
-#define DETAIL_MB_PB11_METHOD_FUNC_static(name_, const_, params_) \
-    +[](DETAIL_MB_PB11_MAKE_PARAM_DECLS(params_)) -> decltype(auto) {return _pb11_C::name_(DETAIL_MB_PB11_MAKE_PARAM_USES(params_));}
+// class being bound. We call through `fullname_` (the name WITH any template arguments, e.g.
+// `tryGet<MR::Foo>`), not the bare `name_`: for template members whose template parameter isn't
+// deducible from the arguments, the old static_cast pinned the instantiation via the target type,
+// whereas a by-name call must name it explicitly. Mirrors the friend-function lambda in
+// `..._FUNC_PTR_OR_LAMBDA_cl` above (and the field-accessor lambda's `_pb11_o.MRBIND_IDENTITY
+// fullname_`), and like them costs an extra move per argument.
+#define DETAIL_MB_PB11_METHOD_FUNC(static_, fullname_, const_, params_) MRBIND_CAT(DETAIL_MB_PB11_METHOD_FUNC_, static_)(fullname_, const_, params_)
+#define DETAIL_MB_PB11_METHOD_FUNC_(fullname_, const_, params_) \
+    +[](_pb11_C const_ &_pb11_self DETAIL_MB_PB11_MAKE_PARAM_DECLS_WITH_LEADING_COMMA(params_)) -> decltype(auto) {return _pb11_self.MRBIND_IDENTITY fullname_(DETAIL_MB_PB11_MAKE_PARAM_USES(params_));}
+#define DETAIL_MB_PB11_METHOD_FUNC_static(fullname_, const_, params_) \
+    +[](DETAIL_MB_PB11_MAKE_PARAM_DECLS(params_)) -> decltype(auto) {return _pb11_C::MRBIND_IDENTITY fullname_(DETAIL_MB_PB11_MAKE_PARAM_USES(params_));}
 
 // A helper for `DETAIL_MB_PB11_DISPATCH_MEMBERS` that generates a method.
 #define DETAIL_MB_PB11_DISPATCH_MEMBER_method(qualname_, static_, assignment_kind_, ret_, name_, simplename_, fullname_, const_, deprecated_, comment_, params_, lifetimes_) \
@@ -3884,7 +3888,7 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         /* selects the const/non-const overload via the object's const-ness, taking no address of */\
         /* an overloaded member. (`ret_` is intentionally unused now; `decltype(auto)` re-deduces.) */\
         /* Upstream MSVC bug: https://developercommunity.visualstudio.com/t/C2440:-static_cast-to-select-an-overload/11107969 */\
-        DETAIL_MB_PB11_DEPRECATION_WRAPPER( MRBIND_STR(MRBIND_IDENTITY fullname_), deprecated_, DETAIL_MB_PB11_METHOD_FUNC(static_, name_, const_, params_) ) \
+        DETAIL_MB_PB11_DEPRECATION_WRAPPER( MRBIND_STR(MRBIND_IDENTITY fullname_), deprecated_, DETAIL_MB_PB11_METHOD_FUNC(static_, fullname_, const_, params_) ) \
         /* Parameter types: */\
         /* Self parameter. */\
         MRBIND_CAT(DETAIL_MB_PB11_IF_STATIC_, static_)(,MRBIND_COMMA() _pb11_C &)\

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -3883,6 +3883,7 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         /* (`auto`) return type, and `C` is a class template -- GCC and Clang accept it. The lambda */\
         /* selects the const/non-const overload via the object's const-ness, taking no address of */\
         /* an overloaded member. (`ret_` is intentionally unused now; `decltype(auto)` re-deduces.) */\
+        /* Upstream MSVC bug: https://developercommunity.visualstudio.com/t/C2440:-static_cast-to-select-an-overload/11107969 */\
         DETAIL_MB_PB11_DEPRECATION_WRAPPER( MRBIND_STR(MRBIND_IDENTITY fullname_), deprecated_, DETAIL_MB_PB11_METHOD_FUNC(static_, name_, const_, params_) ) \
         /* Parameter types: */\
         /* Self parameter. */\

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -3861,14 +3861,29 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         DETAIL_MB_PB11_KEEP_ALIVE(lifetimes_) \
     );
 
+// Produces the callable that binds a member function (see the NOTE in `..._method` below for why
+// this is a forwarding lambda rather than a `static_cast`ed pointer-to-member). `_pb11_C` is the
+// class being bound. Mirrors the friend-function lambda in `..._FUNC_PTR_OR_LAMBDA_cl` above, and
+// like it costs an extra move per argument.
+#define DETAIL_MB_PB11_METHOD_FUNC(static_, name_, const_, params_) MRBIND_CAT(DETAIL_MB_PB11_METHOD_FUNC_, static_)(name_, const_, params_)
+#define DETAIL_MB_PB11_METHOD_FUNC_(name_, const_, params_) \
+    +[](_pb11_C const_ &_pb11_self DETAIL_MB_PB11_MAKE_PARAM_DECLS_WITH_LEADING_COMMA(params_)) -> decltype(auto) {return _pb11_self.name_(DETAIL_MB_PB11_MAKE_PARAM_USES(params_));}
+#define DETAIL_MB_PB11_METHOD_FUNC_static(name_, const_, params_) \
+    +[](DETAIL_MB_PB11_MAKE_PARAM_DECLS(params_)) -> decltype(auto) {return _pb11_C::name_(DETAIL_MB_PB11_MAKE_PARAM_USES(params_));}
+
 // A helper for `DETAIL_MB_PB11_DISPATCH_MEMBERS` that generates a method.
 #define DETAIL_MB_PB11_DISPATCH_MEMBER_method(qualname_, static_, assignment_kind_, ret_, name_, simplename_, fullname_, const_, deprecated_, comment_, params_, lifetimes_) \
     MRBind::pb11::TryAddFunc< \
         /* Is this function static? */\
         MRBind::pb11::FuncKind:: MRBIND_CAT(DETAIL_MB_PB11_IF_STATIC_, static_)(nonmember_or_static, member_nonstatic),\
-        /* Member pointer. */\
-        /* Cast to the correct type to handle overloads correctly. Interestingly, the cast can cast away `noexcept` just fine. I don't think we care about it? */\
-        DETAIL_MB_PB11_DEPRECATION_WRAPPER( MRBIND_STR(MRBIND_IDENTITY fullname_), deprecated_, static_cast<std::type_identity_t<MRBIND_IDENTITY ret_>(MRBIND_CAT(DETAIL_MB_PB11_IF_STATIC_, static_)(,MRBIND_IDENTITY qualname_::)*)(DETAIL_MB_PB11_PARAM_TYPES(params_)) const_>(&MRBIND_IDENTITY qualname_:: name_) ) \
+        /* The callable to bind. */\
+        /* NOTE: a forwarding lambda, NOT `static_cast<Ret (C::*)(...) const_>(&C::name_)`. MSVC */\
+        /* (through 19.5x / VS 2026) rejects that cast with "C2440: ... none of the functions with */\
+        /* this name in scope match the target type" when `name_` is overloaded, has a deduced */\
+        /* (`auto`) return type, and `C` is a class template -- GCC and Clang accept it. The lambda */\
+        /* selects the const/non-const overload via the object's const-ness, taking no address of */\
+        /* an overloaded member. (`ret_` is intentionally unused now; `decltype(auto)` re-deduces.) */\
+        DETAIL_MB_PB11_DEPRECATION_WRAPPER( MRBIND_STR(MRBIND_IDENTITY fullname_), deprecated_, DETAIL_MB_PB11_METHOD_FUNC(static_, name_, const_, params_) ) \
         /* Parameter types: */\
         /* Self parameter. */\
         MRBIND_CAT(DETAIL_MB_PB11_IF_STATIC_, static_)(,MRBIND_COMMA() _pb11_C &)\


### PR DESCRIPTION
## Problem

Member functions are bound by disambiguating overloads with a pointer-to-member cast:

```cpp
static_cast<Ret (C::*)(Args) const>(&C::name)
```

MSVC (through 19.5x / VS 2026) **rejects** that cast when the member is **overloaded**, has a **deduced (`auto`) return type**, and the enclosing class is a **template** — all three are required:

```
error C2440: 'static_cast': cannot convert from 'overloaded-function' to '... (C::*)(...)'
note: None of the functions with this name in scope match the target type
```

GCC and Clang accept it. In MeshLib this hits e.g. `MR::Buffer<T,I>::data()`:

```cpp
[[nodiscard]] auto data()       { return data_.get(); }
[[nodiscard]] auto data() const { return data_.get(); }
```

Minimal repro (Clang 22 and GCC 15 compile; MSVC 19.5x fails), **https://gcc.godbolt.org/z/nKnd5ffbE** :

```cpp
template <class T>
struct B {
    T* p = nullptr;
    auto data()       { return p; }
    auto data() const { return p; }
};
auto f() { return static_cast<int* (B<int>::*)()>( &B<int>::data ); }
```

Every pointer-forming spelling fails the same way on MSVC (`static_cast`, C-style cast, typed-init of a member pointer) — the failure is resolving the address of the overload set against a target type, not the cast itself.

## Fix

Bind the member via a **captureless forwarding lambda** instead of a pointer-to-member:

```cpp
+[](_pb11_C const_ &self, /*params*/) -> decltype(auto) { return self.name(/*params*/); }
```

The lambda calls the function **by name on a concrete object**, so the const/non-const overload is selected by the object's const-ness and the address of an overloaded member is never taken. Being captureless, it decays (via the leading `+`) to a function pointer, so it remains a valid non-type template argument to `TryAddFunc`, and `TryAddFunc` is unchanged.

This mirrors how friend functions are already bound (`DETAIL_MB_PB11_FUNC_PTR_OR_LAMBDA_cl`), reuses the existing `DETAIL_MB_PB11_MAKE_PARAM_DECLS` / `_USES` helpers, and shares the same documented "extra move per argument" cost. Static methods get the no-`self` variant calling `_pb11_C::name(...)`.

## Scope / notes

- Touches only `DETAIL_MB_PB11_DISPATCH_MEMBER_method` in `targets/pybind11/core.h`. The generated `.cpp` (from `data_to_macros`) is unchanged — the same macro invocations now expand to a lambda.
- Conversion operators (`DETAIL_MB_PB11_DISPATCH_MEMBER_conv_op`) keep their cast: their return type is explicit (`operator T`), not deduced, so they don't hit the bug.
- The lambda calls `name_` unqualified to preserve virtual dispatch; this matches the common case where the method is defined in the class being bound. Worth a look for inherited members that are *name-hidden* in a derived class (the old cast named the base explicitly) — flagging for review.
- Upstream MSVC bug report: https://developercommunity.visualstudio.com/t/C2440:-static_cast-to-select-an-overload/11107969

Validated end-to-end against MSVC by building MeshLib's Python bindings with MSVC (MeshLib PR #6272).
