### PR TITLE
Python tests: check that the registration order doesn't depend on the fragment link order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /test/**/*.so
 /test/**/bin
 /test/**/obj
+/test/order_check/output
 parallel-hashmap/
 /examples/cxx.txt
 /examples/c/output

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -39,8 +39,10 @@
 
 // Enable this macro for only one TU.
 #if MB_DEFINE_IMPLEMENTATION
+#include <algorithm> // For `std::sort` to keep the type registration order deterministic.
 #include <cstdio> // To report debug info if enabled. Also for deprecation warnings.
 #include <cstdlib> // For `getenv` to enable debug logging, also `atoi` to parse the loglevel env variable.
+#include <cstring> // For `std::strcmp` when sorting the types.
 #include <exception> // For `std::terminate()`.
 #include <iostream> // To report errors.
 #include <mrbind/helpers/strings.h>
@@ -3099,7 +3101,10 @@ PYBIND11_MODULE(MB_PB11_MODULE_NAME, m)
         {
             // Here `.python_type_name[_qual]` are not initialized yet, and they need to be initialized in the
             //   topological order, so it's easier to use the C++ type names.
-            return a->second.cpp_type_name < b->second.cpp_type_name;
+            if (int d = a->second.cpp_type_name.compare(b->second.cpp_type_name); d != 0)
+                return d < 0;
+            // The pretty names are normally unique, but `std::sort` is unstable, so tie-break by the mangled name just in case.
+            return std::strcmp(a->first.name(), b->first.name()) < 0;
         };
         std::sort(final_order.begin(), final_order.end(), TypeNameLess);
         // Now extract the types that have reverse dependencies into the queue.
@@ -3121,7 +3126,6 @@ PYBIND11_MODULE(MB_PB11_MODULE_NAME, m)
                 queue.pop_back();
 
                 // Get rdeps into a vector and sort them by Python names, to produce stable ordering across platforms.
-                std::vector<decltype(queue)::value_type> sorted_rdeps;
                 sorted_rdeps.clear();
                 sorted_rdeps.reserve(e.second.type_rdeps.size());
                 for (MRBind::TypeIndex rdep : e.second.type_rdeps)
@@ -3290,8 +3294,19 @@ PYBIND11_MODULE(MB_PB11_MODULE_NAME, m)
                 throw std::runtime_error("Python name `" + elem.second.pybind_type_name + "` refers to more than one type.");
         }
 
-        for (const auto &[spelling, types] : r.type_aliases)
+        // Load the aliases in a sorted order. `type_aliases` is unordered, and its iteration order follows the
+        //   registration (= fragment link) order; without sorting, when two alias spellings map to the same Python
+        //   name, which one wins the assignment below would depend on that order.
+        std::vector<const typename decltype(Registry::type_aliases)::value_type *> sorted_type_aliases;
+        sorted_type_aliases.reserve(r.type_aliases.size());
+        for (const auto &elem : r.type_aliases)
+            sorted_type_aliases.push_back(&elem);
+        std::sort(sorted_type_aliases.begin(), sorted_type_aliases.end(), [](const auto *a, const auto *b){return a->first < b->first;});
+
+        for (const auto *alias_elem : sorted_type_aliases)
         {
+            const auto &[spelling, types] = *alias_elem;
+
             if (types.size() > 1)
                 continue; // More than one target type, so this is ambiguous (somehow). Ignore this one.
 
@@ -3342,6 +3357,9 @@ PYBIND11_MODULE(MB_PB11_MODULE_NAME, m)
             }
             if (!entry.aliases.empty())
             {
+                // The aliases were collected in the iteration order of `Registry::type_aliases`, which isn't deterministic. Sort them.
+                std::sort(entry.aliases.begin(), entry.aliases.end());
+
                 doc += "Aliases:  ";
                 bool first = true;
                 for (const auto& alias : entry.aliases)

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -40,10 +40,8 @@
 
 // Enable this macro for only one TU.
 #if MB_DEFINE_IMPLEMENTATION
-#include <algorithm> // For `std::sort` to keep the type registration order deterministic.
 #include <cstdio> // To report debug info if enabled. Also for deprecation warnings.
 #include <cstdlib> // For `getenv` to enable debug logging, also `atoi` to parse the loglevel env variable.
-#include <cstring> // For `std::strcmp` when sorting the types.
 #include <exception> // For `std::terminate()`.
 #include <iostream> // To report errors.
 #include <mrbind/helpers/strings.h>
@@ -3103,10 +3101,7 @@ PYBIND11_MODULE(MB_PB11_MODULE_NAME, m)
         {
             // Here `.python_type_name[_qual]` are not initialized yet, and they need to be initialized in the
             //   topological order, so it's easier to use the C++ type names.
-            if (int d = a->second.cpp_type_name.compare(b->second.cpp_type_name); d != 0)
-                return d < 0;
-            // The pretty names are normally unique, but `std::sort` is unstable, so tie-break by the mangled name just in case.
-            return std::strcmp(a->first.name(), b->first.name()) < 0;
+            return a->second.cpp_type_name < b->second.cpp_type_name;
         };
         std::sort(final_order.begin(), final_order.end(), TypeNameLess);
         // Now extract the types that have reverse dependencies into the queue.
@@ -3296,19 +3291,8 @@ PYBIND11_MODULE(MB_PB11_MODULE_NAME, m)
                 throw std::runtime_error("Python name `" + elem.second.pybind_type_name + "` refers to more than one type.");
         }
 
-        // Load the aliases in a sorted order. `type_aliases` is unordered, and its iteration order follows the
-        //   registration (= fragment link) order; without sorting, when two alias spellings map to the same Python
-        //   name, which one wins the assignment below would depend on that order.
-        std::vector<const typename decltype(Registry::type_aliases)::value_type *> sorted_type_aliases;
-        sorted_type_aliases.reserve(r.type_aliases.size());
-        for (const auto &elem : r.type_aliases)
-            sorted_type_aliases.push_back(&elem);
-        std::sort(sorted_type_aliases.begin(), sorted_type_aliases.end(), [](const auto *a, const auto *b){return a->first < b->first;});
-
-        for (const auto *alias_elem : sorted_type_aliases)
+        for (const auto &[spelling, types] : r.type_aliases)
         {
-            const auto &[spelling, types] = *alias_elem;
-
             if (types.size() > 1)
                 continue; // More than one target type, so this is ambiguous (somehow). Ignore this one.
 
@@ -3359,9 +3343,6 @@ PYBIND11_MODULE(MB_PB11_MODULE_NAME, m)
             }
             if (!entry.aliases.empty())
             {
-                // The aliases were collected in the iteration order of `Registry::type_aliases`, which isn't deterministic. Sort them.
-                std::sort(entry.aliases.begin(), entry.aliases.end());
-
                 doc += "Aliases:  ";
                 bool first = true;
                 for (const auto& alias : entry.aliases)

--- a/test/check_py_registration_order.sh
+++ b/test/check_py_registration_order.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Checks that the Python bindings don't depend on the link order of the fragment object files.
+#
+# The types are registered into the `Registry` by static initializers, whose order across the fragment
+# TUs follows the link order, and the iteration order of the unordered containers in the registry
+# depends on that insertion order. Since the topological type sort used to break ties by iteration
+# order, merely relinking the same object files in a different order used to change the position of
+# the `__init__` overloads injected from conversion operators (and with it pybind11's overload
+# resolution) and the docstring alias lists. This script fails with a diff in that case.
+
+set -euxo pipefail
+
+if [[ "$(uname -o)" == Msys ]]; then
+    EXT_MODULE=.pyd
+    CXX=clang++
+else
+    EXT_MODULE=.so
+    CXX=clang++-20
+fi
+
+OUT=test/order_check/output
+mkdir -p "$OUT"
+
+# Clone Pybind if missing:
+[[ -d test/input_py/pybind11 ]] || git clone https://github.com/pybind/pybind11 test/input_py/pybind11
+
+build/mrbind \
+    test/order_check/input/MR/order.h \
+    --format=macros \
+    --ignore :: \
+    --allow MR \
+    --combine-types=cv,ref,ptr,smart_ptr \
+    -o "$OUT/parsed.cpp" \
+    -- \
+    -xc++-header \
+    -std=c++23 \
+    -Wall \
+    -Wextra \
+    -pedantic-errors \
+    -fparse-all-comments
+
+# Compile as 4 fragments.
+for i in 0 1 2 3; do
+    impl=()
+    [[ $i == 0 ]] && impl=(-DMB_DEFINE_IMPLEMENTATION)
+    "$CXX" \
+        "$OUT/parsed.cpp" \
+        -c -fPIC -o "$OUT/frag_$i.o" \
+        -DMB_NUM_FRAGMENTS=4 -DMB_FRAGMENT=$i "${impl[@]}" \
+        -DMRBIND_HEADER='<mrbind/targets/pybind11.h>' \
+        -DMB_PB11_MODULE_NAME=example \
+        -DPYBIND11_COMPILER_TYPE='"_myexample"' -DPYBIND11_BUILD_ABI='"_myexample"' \
+        -I. \
+        -Iinclude \
+        -Itest/input_py/pybind11/include \
+        -std=c++20 -Wall -Wextra \
+        `python3-config --cflags`
+done
+
+# Link the same objects in two different orders.
+mkdir -p "$OUT/ord1" "$OUT/ord2"
+"$CXX" -shared -o "$OUT/ord1/example$EXT_MODULE" "$OUT"/frag_{0,1,2,3}.o `python3-config --ldflags --embed`
+"$CXX" -shared -o "$OUT/ord2/example$EXT_MODULE" "$OUT"/frag_{0,3,2,1}.o `python3-config --ldflags --embed`
+
+# Dump the ordering observables: the type registration log, and the docstrings of the class that
+# receives the `__init__` overloads injected from the conversion operators.
+for ord in ord1 ord2; do
+    (cd "$OUT/$ord" && MRBIND_DEBUG=2 python3 -c '
+import example
+print(example.MR.Target.__doc__)
+print(example.MR.Target.__init__.__doc__)
+' 2>&1 | grep -E "mrbind: Registering (type|alias)|Aliases:|__init__") >"$OUT/dump_$ord.txt"
+done
+
+diff "$OUT/dump_ord1.txt" "$OUT/dump_ord2.txt"
+
+echo 'Success! Both link orders produce identically ordered bindings.'

--- a/test/order_check/input/MR/order.h
+++ b/test/order_check/input/MR/order.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// Input for `test/check_py_registration_order.sh`.
+
+namespace MR
+{
+    // The target type. The conversion operators of the classes below inject `__init__` overloads into it,
+    // and the relative order of those overloads (which affects pybind11's overload resolution) follows
+    // the type registration order.
+    struct Target
+    {
+        int value = 0;
+        Target() {}
+        explicit Target(int v) : value(v) {}
+    };
+
+    struct SrcAlpha   { int x = 1;  operator Target() const {return Target(x);} };
+    struct SrcBravo   { int x = 2;  operator Target() const {return Target(x);} };
+
+    // Aliases for one type, to also cover the `Aliases:` docstring line. Deliberately spread over the
+    // file, so that they land in different fragments and their registration order follows the link order.
+    using TargetAliasOne = Target;
+
+    struct SrcCharlie { int x = 3;  operator Target() const {return Target(x);} };
+    struct SrcDelta   { int x = 4;  operator Target() const {return Target(x);} };
+
+    using TargetAliasTwo = Target;
+
+    struct SrcEcho    { int x = 5;  operator Target() const {return Target(x);} };
+    struct SrcFoxtrot { int x = 6;  operator Target() const {return Target(x);} };
+
+    typedef Target TargetAliasThree;
+
+    struct SrcGolf    { int x = 7;  operator Target() const {return Target(x);} };
+    struct SrcHotel   { int x = 8;  operator Target() const {return Target(x);} };
+
+    using TargetAliasFour = Target;
+
+    // Some extra types to pad the type graph.
+    template <typename T>
+    struct Box { T payload{}; };
+
+    inline Box<SrcAlpha>   MakeBoxAlpha()   {return {};}
+    inline Box<SrcBravo>   MakeBoxBravo()   {return {};}
+    inline Box<SrcCharlie> MakeBoxCharlie() {return {};}
+    inline Box<Target>     MakeBoxTarget()  {return {};}
+
+    using TargetAliasFive = Target;
+}


### PR DESCRIPTION
Adds a regression check for the deterministic registration order of the Python bindings, locking in the guarantees introduced by 236ba967 (deterministic topological type sort) and f2764c51 (deterministic alias ordering).

### What it checks

The types and aliases are registered by static initializers, so their registration order across the fragment TUs follows the link order, and until the two commits above the bindings visibly depended on it: relinking the same objects in a different order moved the `__init__` overloads injected from conversion operators (which affects pybind11's overload resolution), and shuffled the `Aliases:` docstring lines.

`test/check_py_registration_order.sh`:

1. generates bindings for `test/order_check/input/MR/order.h` — 8 classes with conversion operators into one `Target` class, plus 5 type aliases of it, deliberately spread across the file so that they land in different fragments (adjacent declarations would end up in the same fragment and could never shuffle);
2. compiles them as 4 fragments and links the same object files in two orders: `0 1 2 3` and `0 3 2 1`;
3. imports both modules and requires their `MRBIND_DEBUG=2` type/alias registration log, `Target`'s docstring, and its `__init__` overload list to be identical.

### Status

- On current master the check passes: the full `MRBIND_DEBUG=2` dump is byte-identical between the two link orders.
- On 236ba967 it failed on the `Aliases:` docstring line; before 236ba967 also on the type registration order and the injected `__init__` overload positions:

```diff
-    3. __init__(self: example.MR.Target, arg0: example.MR.SrcCharlie) -> None
+    3. __init__(self: example.MR.Target, arg0: example.MR.SrcDelta) -> None
```

The branch history keeps the earlier implementation commits (now superseded by the master ones and reverted), so the net diff is just the check and its input.
