### PR TITLE
Tests: cover default arguments that mention class members without qualification

### DIFF
--- a/test/input_py/MR/1.h
+++ b/test/input_py/MR/1.h
@@ -50,4 +50,15 @@ namespace MR
     struct B : virtual A {};
 
     struct C : B {};
+
+    // The default arguments here mention class members and enum constants without full qualification.
+    // Check that they get fully qualified in the generated code, which is outside of this scope.
+    struct DefaultArgsMentioningMembers
+    {
+        static constexpr int limit = 42;
+        enum E {e0, e1};
+
+        void ByStaticMember(int n = limit) {(void)n;}
+        void ByEnumConstant(E e = e1) {(void)e;}
+    };
 }


### PR DESCRIPTION
Follow-up to #41 / 3e01103b: adds regression coverage for the motivating case — default arguments that mention **class-scope** names without qualification, which no `using namespace` can resolve in the generated code:

```cpp
struct DefaultArgsMentioningMembers
{
    static constexpr int limit = 42;
    enum E {e0, e1};

    void ByStaticMember(int n = limit) {(void)n;}
    void ByEnumConstant(E e = e1) {(void)e;}
};
```

Added to `test/input_py/MR/1.h`, where `make_py.sh` runs the parser in the default `fix` mode. The compile step of the generated pybind module is the actual check: if the parser stops fully qualifying these names, the generated code fails with `use of undeclared identifier 'limit'` (verified by running the generated output through the old parser behavior).

Two things I noticed while preparing this, both intentional non-changes:

* I did not add the struct to `test/input` (the C/C# suite): `make_c.sh` generates the plain `output_c` with `--default-args=as-is`, where class-scope names are unfixable by design, so the generated `output_c` sources would not compile. (The `fixed_typedefs` rounds, which use the default `fix` mode, handle it fine — I checked.)
* I did not touch `test/output_py/parsed.cpp`: it appears stale on master (last regenerated in 9f60d8b0 — e.g. `MB_FUNC` entries there predate the lifetime-info argument), and a regen embeds machine-specific absolute paths anyway, so I left it for your usual regeneration flow, which will also pick up the new struct.

Verified on Windows/MSYS2 CLANG64 (clang 22.1.4): `make_py.sh` generation + compile of the module succeeds with current master, and the emitted macros contain the fully qualified defaults (`(MR::DefaultArgsMentioningMembers::limit)`).
