### PR TITLE
Python: always pass the doc comment as a possibly-null pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MRBind is meant to cover a large API surface area with minimal effort, but in tu
 
 All MRBind features were developed without any use of AI.
 
-I received some trivial vibecoded bugfix PRs that were merged after manual cleanup (which among other things includes replacing generated comments). I've also merged some generated testcases for those bugs.
+I received some simple vibecoded contributions (bugfixes, binary size reductions) that were merged after manual cleanup, which among other things includes replacing the generated comments. I've also merged some generated testcases for those bugs.
 
 ## Usage
 

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -3668,12 +3668,12 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
 #define DETAIL_MB_PB11_CONV_OP_KIND_() MRBind::pb11::FuncKind::conv_op
 #define DETAIL_MB_PB11_CONV_OP_KIND_explicit() MRBind::pb11::FuncKind::conv_op_explicit
 
-// If the parameter is empty, returns `nullptr`. Otherwise prepends `+`. This is intended for optional comment strings, and `+` forces a conversion to a pointer, which helps reduce the number of instantiations.
-// Prefer this over conditionally passing the comment at all: pybind11 treats a null `const char *`
-//   attribute exactly like an absent one, so always passing it keeps entities with and without a
-//   comment on the same `cpp_function` instantiation instead of doubling the shapes.
+// If the parameter is empty, returns `(const char *)nullptr`. Otherwise prepends `+`. This is intended for optional comment strings, and `+` forces a conversion to a pointer, which helps reduce the number of instantiations.
+// The cast on `nullptr` is there for the same reason, to reduce the number of instantiations.
+// It's good to use this macro instead of conditionally passing the comment, since it too reduces the number of instantiations,
+//   and Pybind apparently treats the null pointers as if no comment was passed at all.
 #define DETAIL_MB_PB11_COMMENT_PTR(...) MRBIND_CAT(DETAIL_MB_PB11_COMMENT_PTR_, __VA_OPT__(1))(__VA_ARGS__)
-#define DETAIL_MB_PB11_COMMENT_PTR_(...) nullptr
+#define DETAIL_MB_PB11_COMMENT_PTR_(...) ((const char *)nullptr)
 #define DETAIL_MB_PB11_COMMENT_PTR_1(...) +__VA_ARGS__
 
 // Returns the "namespace marker" class for the given namespace stack.
@@ -3758,9 +3758,9 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
                 /* Pybind extras: */\
                 [](auto _pb11_f){_pb11_f(MRBIND_STRIP_LEADING_COMMA( \
                     /* Parameters. */\
-                    DETAIL_MB_PB11_MAKE_PARAMS(params_) \
+                    DETAIL_MB_PB11_MAKE_PARAMS(params_), \
                     /* Comment, possibly null. */ \
-                    , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_) \
+                    DETAIL_MB_PB11_COMMENT_PTR(comment_) \
                     /* Lifetime annotations. */ \
                     DETAIL_MB_PB11_KEEP_ALIVE(lifetimes_) \
                 ));} \
@@ -3893,9 +3893,9 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         >(\
             _pb11_c,\
             /* Name. */\
-            MRBind::pb11::ToPythonName(MRBIND_STR(MRBIND_IDENTITY fullname_)).c_str()\
+            MRBind::pb11::ToPythonName(MRBIND_STR(MRBIND_IDENTITY fullname_)).c_str(),\
             /* Comment, possibly null. */\
-            , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_)\
+            DETAIL_MB_PB11_COMMENT_PTR(comment_)\
         ); \
         /* Add `offsetof` static variables. */\
         MRBIND_CAT(DETAIL_MB_PB11_DISPATCH_MEMBER_field_OFFSETOF_,static_)(qualname_, name_) \
@@ -3926,9 +3926,9 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         _pb11_c, \
         &_pb11_state.func_scope_state, _pb11_state.pass_number \
         /* Parameters. */\
-        DETAIL_MB_PB11_MAKE_PARAMS(params_) \
+        DETAIL_MB_PB11_MAKE_PARAMS(params_), \
         /* Comment, possibly null. */\
-        , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_)\
+        DETAIL_MB_PB11_COMMENT_PTR(comment_)\
         /* Lifetime annotations. */ \
         DETAIL_MB_PB11_KEEP_ALIVE(lifetimes_) \
     );
@@ -3963,9 +3963,9 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         /* Pybind extras: */\
         [](auto _pb11_f){_pb11_f(MRBIND_STRIP_LEADING_COMMA( \
             /* Parameters. */\
-            DETAIL_MB_PB11_MAKE_PARAMS(params_) \
+            DETAIL_MB_PB11_MAKE_PARAMS(params_), \
             /* Comment, possibly null. */ \
-            , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_) \
+            DETAIL_MB_PB11_COMMENT_PTR(comment_) \
             /* Lifetime annotations. */ \
             DETAIL_MB_PB11_KEEP_ALIVE(lifetimes_) \
         ));} \

--- a/include/mrbind/targets/pybind11/core.h
+++ b/include/mrbind/targets/pybind11/core.h
@@ -3669,6 +3669,9 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
 #define DETAIL_MB_PB11_CONV_OP_KIND_explicit() MRBind::pb11::FuncKind::conv_op_explicit
 
 // If the parameter is empty, returns `nullptr`. Otherwise prepends `+`. This is intended for optional comment strings, and `+` forces a conversion to a pointer, which helps reduce the number of instantiations.
+// Prefer this over conditionally passing the comment at all: pybind11 treats a null `const char *`
+//   attribute exactly like an absent one, so always passing it keeps entities with and without a
+//   comment on the same `cpp_function` instantiation instead of doubling the shapes.
 #define DETAIL_MB_PB11_COMMENT_PTR(...) MRBIND_CAT(DETAIL_MB_PB11_COMMENT_PTR_, __VA_OPT__(1))(__VA_ARGS__)
 #define DETAIL_MB_PB11_COMMENT_PTR_(...) nullptr
 #define DETAIL_MB_PB11_COMMENT_PTR_1(...) +__VA_ARGS__
@@ -3756,8 +3759,8 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
                 [](auto _pb11_f){_pb11_f(MRBIND_STRIP_LEADING_COMMA( \
                     /* Parameters. */\
                     DETAIL_MB_PB11_MAKE_PARAMS(params_) \
-                    /* Comment, if any. */ \
-                    MRBIND_PREPEND_COMMA(comment_) \
+                    /* Comment, possibly null. */ \
+                    , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_) \
                     /* Lifetime annotations. */ \
                     DETAIL_MB_PB11_KEEP_ALIVE(lifetimes_) \
                 ));} \
@@ -3891,8 +3894,8 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
             _pb11_c,\
             /* Name. */\
             MRBind::pb11::ToPythonName(MRBIND_STR(MRBIND_IDENTITY fullname_)).c_str()\
-            /* Comment, if any. */\
-            DETAIL_MB_PB11_PREPEND_COMMA_PLUS(comment_)\
+            /* Comment, possibly null. */\
+            , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_)\
         ); \
         /* Add `offsetof` static variables. */\
         MRBIND_CAT(DETAIL_MB_PB11_DISPATCH_MEMBER_field_OFFSETOF_,static_)(qualname_, name_) \
@@ -3924,8 +3927,8 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         &_pb11_state.func_scope_state, _pb11_state.pass_number \
         /* Parameters. */\
         DETAIL_MB_PB11_MAKE_PARAMS(params_) \
-        /* Comment, if any. */\
-        DETAIL_MB_PB11_PREPEND_COMMA_PLUS(comment_) \
+        /* Comment, possibly null. */\
+        , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_)\
         /* Lifetime annotations. */ \
         DETAIL_MB_PB11_KEEP_ALIVE(lifetimes_) \
     );
@@ -3961,8 +3964,8 @@ static_assert(std::is_same_v<MRBind::RebindContainer<std::array<int, 4>, float>,
         [](auto _pb11_f){_pb11_f(MRBIND_STRIP_LEADING_COMMA( \
             /* Parameters. */\
             DETAIL_MB_PB11_MAKE_PARAMS(params_) \
-            /* Comment, if any. */ \
-            MRBIND_PREPEND_COMMA(comment_) \
+            /* Comment, possibly null. */ \
+            , (const char *)DETAIL_MB_PB11_COMMENT_PTR(comment_) \
             /* Lifetime annotations. */ \
             DETAIL_MB_PB11_KEEP_ALIVE(lifetimes_) \
         ));} \


### PR DESCRIPTION
A deliberately minimal alternative to #44: four functional lines, no structural change, and it still measurably shrinks the generated modules.

## The idea

`cpp_function` is instantiated per set of pybind11 extras, so `def(name, f, arg("x"), "a comment")` and `def(name, f, arg("x"))` produce two separate instantiations even when the signature is identical. Since roughly half of MeshLib's bound entities carry a doc comment and half do not, that doubles a large number of shapes for no reason.

pybind11 treats a null `const char *` attribute exactly like an absent one - `process_attribute<const char *>::init` just assigns it to `function_record::doc`, and `doc` defaults to null anyway - so the comment can be passed unconditionally, as a null pointer when there is none. Entities with and without a comment then land on the same instantiation.

`DETAIL_MB_PB11_COMMENT_PTR` already existed for exactly this shape, so this is mostly a matter of using it at four more call sites: methods, free functions, fields and constructors. The `(const char *)` cast is needed because the macro's empty case expands to a bare `nullptr`, which would otherwise deduce as `std::nullptr_t` and fail to find a `process_attribute` specialization.

## Results

Synthetic module (40 classes x 20 methods + 240 fields + 200 free functions, **half of them commented and half not**, to mirror the real mix), Clang 22, `-Oz`, no LTO or ICF, same generated `.cpp`:

| | `.text` | delta |
|---|---|---|
| master `5d6f332e` | 4,270,502 | - |
| + methods and free functions | 4,176,038 | -2.21% |
| + fields and constructors | 4,172,838 | **-2.29%** |

MeshLib `mrmeshpy.so`, same MeshLib commit (`e435a34c9`) with the default `MODE=release` (so `-Oz -flto=thin` and `-Wl,--icf=all`), varying only the mrbind gitlink, baseline = master `5d6f332e`:

| | compressed (in wheel) | unpacked | `.text` | `meshlib-core` wheel |
|---|---|---|---|---|
| x86_64 | -0.78% | -0.34% | **-1.30%** | -0.22% |
| aarch64 | **-1.30%** | **-1.30%** | **-1.77%** | -0.35% |

Absolute numbers, x86_64: compressed 15,573,029 -> 15,451,650, `.text` 29,345,354 -> 28,964,952. aarch64: compressed 14,056,202 -> 13,874,118, `.text` 17,687,800 -> 17,374,664.

Smaller than the synthetic benchmark predicted (-2.29% of `.text` there), which is expected - the real commented/uncommented mix is not 50/50 and many shapes are unique regardless. Still a measurable reduction for four lines, and unlike #44 it is a pure code reduction: no data or relocations are added, so the unpacked size drops too rather than staying flat.

`.text` is quoted because it is deterministic to the byte; on Windows `stripped + xz` is not reproducible across rebuilds of identical source, so it is not a usable metric at this scale.

## Behavior is unchanged

A dump of `pydoc.render_doc()`, every attribute's `repr` and `__doc__`, every property's `fget`/`fset`/`fdel` with their `__doc__` and `__name__`, plus ~50 live calls and field round-trips, is byte-identical to master's on two inputs - a feature test with a deliberate mix of commented and uncommented methods, free functions, fields, static fields and constructors, and a second input covering the standard containers and smart pointers. Also passes `-fsyntax-only` against the MeshInspector pybind11 fork with MeshLib's limited-API defines.

## Relationship to the other PRs

Independent of, and much smaller than, #44. #44 contains this same change as one of its parts, so if #44 lands this one is redundant; if #44 is judged too invasive, this captures a small slice of the win on its own. It is also orthogonal to `5d6f332e` - that one shrank the code inside `TryAddFunc`, this one reduces how many times `cpp_function` is instantiated - and it is measured on top of it.

## One thing I tried and rejected

Sharing the `_offsetof_*` getter lambda instead of emitting a captureless one per field looked like an obvious win and is **not** one. A single shared capturing lambda costs +0.29% of `.text` and a per-field capturing one +1.1%, because master's `+[]` decays to a plain function pointer and hits pybind11's lean `initialize` overload, while any closure takes the generic one. The per-field lambda bodies it would replace are only a few instructions each. Master is already doing the right thing there. (I had listed this as a win in #44's description; that is now corrected.)
