### PR TITLE
C#: use LayoutKind.Sequential for single-field exposed structs (IL2CPP wasm ABI)

### DIFF
--- a/docs/generating_csharp.md
+++ b/docs/generating_csharp.md
@@ -182,6 +182,12 @@ Eventually we might add translation from the Doxygen comment annotations to thos
 
 This should be enough to at least display those comments in IDEs, but any `@...` doxygen tags will be left as is, instead of being translated into their proper XML form.
 
+## Exposed structs and Unity's IL2CPP on WebAssembly
+
+Structs exposed via `--expose-as-struct` (see [the C docs](/docs/generating_c.md#expose-simple-structs-as-structs)) are emitted as blittable C# structs with `LayoutKind.Explicit` and explicit field offsets, except structs with a single field, which use `LayoutKind.Sequential`.
+
+The exception exists because of Unity's IL2CPP on WebAssembly. IL2CPP compiles explicit-layout structs to a union with padding, and on wasm32 Clang only passes and returns *single-element* structs as plain scalars, which such a union isn't. So for a one-field struct the IL2CPP-compiled call site would return it through a hidden pointer and pass it by pointer, while the C library returns and accepts a plain scalar (`wasm-ld` reports `function signature mismatch`, and the calls trap or read garbage at runtime). A sequential one-field struct compiles to a plain C struct, which has the same ABI as the C side. Structs with more fields don't have this problem, since both sides pass those indirectly.
+
 ## Distributing the C# bindings as a Nuget package
 
 This is not a full explanation, but a rought outline of what you need to do.

--- a/src/generators/csharp/generator.cpp
+++ b/src/generators/csharp/generator.cpp
@@ -5952,13 +5952,27 @@ namespace mrbind::CSharp
                         WriteComment(file, comment);
                     }
 
+                    // Exposed structs with a single field use `LayoutKind.Sequential` instead of `LayoutKind.Explicit` (for one field both layouts are trivially the same).
+                    // This is for Unity's IL2CPP on wasm32: it compiles explicit-layout structs to a union with padding, and Clang's wasm32 ABI only passes and returns
+                    //   *single-element* structs as plain scalars, which that union isn't. So with `Explicit` the IL2CPP-compiled call site returns a one-field struct
+                    //   through a hidden pointer and passes it by pointer, while the C side returns and accepts a plain scalar (`wasm-ld` warns about `function signature mismatch`,
+                    //   and the calls trap or read garbage). A sequential one-field struct compiles to a plain C struct, which matches. Multi-field structs are indirect on both sides anyway.
+                    const bool exposed_struct_is_sequential = is_exposed_struct_by_value && std::ranges::count_if(class_desc.fields, [](const CInterop::ClassField &field){return !field.is_static;}) == 1;
+
                     // The struct attributes.
                     if (is_exposed_struct_by_value)
                     {
-                        // There's also `Pack = ...` parameter. It looks related to alignment, but the docs say that it only affects
-                        //   the automatic field layout if that's enabled, and not the alignment of the entire struct.
-                        // Instead I'm going to assume that it aligns by the largest field size, and check that below.
-                        file.WriteString("[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = " + std::to_string(class_desc.size_and_alignment.value().size) + ")]\n");
+                        if (exposed_struct_is_sequential)
+                        {
+                            file.WriteString("[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]\n");
+                        }
+                        else
+                        {
+                            // There's also `Pack = ...` parameter. It looks related to alignment, but the docs say that it only affects
+                            //   the automatic field layout if that's enabled, and not the alignment of the entire struct.
+                            // Instead I'm going to assume that it aligns by the largest field size, and check that below.
+                            file.WriteString("[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = " + std::to_string(class_desc.size_and_alignment.value().size) + ")]\n");
+                        }
                     }
 
                     // The class header.
@@ -6619,7 +6633,8 @@ namespace mrbind::CSharp
                                     // Write the field by value, if we're in the by-value part.
                                     if (is_exposed_struct_by_value)
                                     {
-                                        const std::string offset_attr = "[System.Runtime.InteropServices.FieldOffset(" + std::to_string(field.layout.value().byte_offset) + ")]\n";
+                                        // No offsets in sequential structs, `FieldOffset` is only allowed with `LayoutKind.Explicit`.
+                                        const std::string offset_attr = exposed_struct_is_sequential ? "" : "[System.Runtime.InteropServices.FieldOffset(" + std::to_string(field.layout.value().byte_offset) + ")]\n";
 
                                         // Write the field itself.
                                         if (is_bool)

--- a/test/input/MR/test_csharp.h
+++ b/test/input/MR/test_csharp.h
@@ -1065,6 +1065,9 @@ namespace MR::CSharp
         int x;
     };
 
+    // Single-field exposed structs use `LayoutKind.Sequential` in C#. This tests passing and returning one by value.
+    inline ExposedLayoutC test_exposed_c(ExposedLayoutC a, ExposedLayoutC b = {}) {a.x += b.x; return a;}
+
 
     // Test various array members.
     struct ArrayMembers

--- a/test/output_c/include/MR/test_csharp.h
+++ b/test/output_c/include/MR/test_csharp.h
@@ -6312,6 +6312,11 @@ MR_C_API MR_CSharp_ExposedLayoutB MR_CSharp_ExposedLayoutB_Construct_1(const MR_
 /// Parameter `_2` can not be null. It is a single object.
 MR_C_API bool MR_C_equal_MR_CSharp_ExposedLayoutB(const MR_CSharp_ExposedLayoutB *_1, const MR_CSharp_ExposedLayoutB *_2);
 
+// Single-field exposed structs use `LayoutKind.Sequential` in C#. This tests passing and returning one by value.
+/// Generated from function `MR::CSharp::test_exposed_c`.
+/// Parameter `b` has a default argument: `{}`, pass a null pointer to use it.
+MR_C_API MR_CSharp_ExposedLayoutC MR_CSharp_test_exposed_c(MR_CSharp_ExposedLayoutC a, const MR_CSharp_ExposedLayoutC *b);
+
 /// Returns a pointer to a member variable of class `MR::CSharp::ArrayMembers` named `i`.
 /// Parameter `_this` can not be null. It is a single object.
 /// The returned pointer will never be null. It is non-owning, do NOT destroy it.

--- a/test/output_c/source/MR/test_csharp.cpp
+++ b/test/output_c/source/MR/test_csharp.cpp
@@ -9550,6 +9550,18 @@ bool MR_C_equal_MR_CSharp_ExposedLayoutB(const MR_CSharp_ExposedLayoutB *_1, con
     ) // MRBINDC_TRY
 }
 
+MR_CSharp_ExposedLayoutC MR_CSharp_test_exposed_c(MR_CSharp_ExposedLayoutC a, const MR_CSharp_ExposedLayoutC *b)
+{
+    MRBINDC_TRY(
+    using namespace MR;
+    using namespace CSharp;
+    return MRBINDC_BIT_CAST((MR_CSharp_ExposedLayoutC), ::MR::CSharp::test_exposed_c(
+        MRBINDC_BIT_CAST((MR::CSharp::ExposedLayoutC), a),
+        (b ? MRBINDC_BIT_CAST((MR::CSharp::ExposedLayoutC), *b) : MR::CSharp::ExposedLayoutC(MR::CSharp::ExposedLayoutC{}))
+    ));
+    ) // MRBINDC_TRY
+}
+
 const int *MR_CSharp_ArrayMembers_Get_i(const MR_CSharp_ArrayMembers *_this)
 {
     return std::addressof(((_this ? void() : MRBINDC_THROW("Parameter `_this` can not be null.", void)), *(const MR::CSharp::ArrayMembers *)(_this)).i);

--- a/test/output_c_fixed_typedefs/include/MR/test_csharp.h
+++ b/test/output_c_fixed_typedefs/include/MR/test_csharp.h
@@ -6128,6 +6128,11 @@ MR_C_API MR_CSharp_ExposedLayoutB MR_CSharp_ExposedLayoutB_Construct_1(const MR_
 // Parameter `_2` can not be null. It is a single object.
 MR_C_API bool MR_C_equal_MR_CSharp_ExposedLayoutB(const MR_CSharp_ExposedLayoutB *_1, const MR_CSharp_ExposedLayoutB *_2);
 
+// Single-field exposed structs use `LayoutKind.Sequential` in C#. This tests passing and returning one by value.
+// Generated from function `MR::CSharp::test_exposed_c`.
+// Parameter `b` has a default argument: `{}`, pass a null pointer to use it.
+MR_C_API MR_CSharp_ExposedLayoutC MR_CSharp_test_exposed_c(MR_CSharp_ExposedLayoutC a, const MR_CSharp_ExposedLayoutC *b);
+
 // Returns a pointer to a member variable of class `MR::CSharp::ArrayMembers` named `i`.
 // Parameter `_this` can not be null. It is a single object.
 // The returned pointer will never be null. It is non-owning, do NOT destroy it.

--- a/test/output_c_fixed_typedefs/source/MR/test_csharp.cpp
+++ b/test/output_c_fixed_typedefs/source/MR/test_csharp.cpp
@@ -6882,6 +6882,14 @@ bool MR_C_equal_MR_CSharp_ExposedLayoutB(const MR_CSharp_ExposedLayoutB *_1, con
     );
 }
 
+MR_CSharp_ExposedLayoutC MR_CSharp_test_exposed_c(MR_CSharp_ExposedLayoutC a, const MR_CSharp_ExposedLayoutC *b)
+{
+    return MRBINDC_BIT_CAST((MR_CSharp_ExposedLayoutC), ::MR::CSharp::test_exposed_c(
+        MRBINDC_BIT_CAST((MR::CSharp::ExposedLayoutC), a),
+        (b ? MRBINDC_BIT_CAST((MR::CSharp::ExposedLayoutC), *b) : MR::CSharp::ExposedLayoutC(MR::CSharp::ExposedLayoutC{}))
+    ));
+}
+
 const int32_t *MR_CSharp_ArrayMembers_Get_i(const MR_CSharp_ArrayMembers *_this)
 {
     return std::addressof(((_this ? void() : MRBINDC_THROW("Parameter `_this` can not be null.", void)), *(const MR::CSharp::ArrayMembers *)(_this)).i);

--- a/test/output_c_fixed_typedefs_64_only/include/MR/test_csharp.h
+++ b/test/output_c_fixed_typedefs_64_only/include/MR/test_csharp.h
@@ -6311,6 +6311,11 @@ MR_C_API MR_CSharp_ExposedLayoutB MR_CSharp_ExposedLayoutB_Construct_1(const MR_
 /// Parameter `_2` can not be null. It is a single object.
 MR_C_API bool MR_C_equal_MR_CSharp_ExposedLayoutB(const MR_CSharp_ExposedLayoutB *_1, const MR_CSharp_ExposedLayoutB *_2);
 
+// Single-field exposed structs use `LayoutKind.Sequential` in C#. This tests passing and returning one by value.
+/// Generated from function `MR::CSharp::test_exposed_c`.
+/// Parameter `b` has a default argument: `{}`, pass a null pointer to use it.
+MR_C_API MR_CSharp_ExposedLayoutC MR_CSharp_test_exposed_c(MR_CSharp_ExposedLayoutC a, const MR_CSharp_ExposedLayoutC *b);
+
 /// Returns a pointer to a member variable of class `MR::CSharp::ArrayMembers` named `i`.
 /// Parameter `_this` can not be null. It is a single object.
 /// The returned pointer will never be null. It is non-owning, do NOT destroy it.

--- a/test/output_c_fixed_typedefs_64_only/source/MR/test_csharp.cpp
+++ b/test/output_c_fixed_typedefs_64_only/source/MR/test_csharp.cpp
@@ -7138,6 +7138,14 @@ bool MR_C_equal_MR_CSharp_ExposedLayoutB(const MR_CSharp_ExposedLayoutB *_1, con
     );
 }
 
+MR_CSharp_ExposedLayoutC MR_CSharp_test_exposed_c(MR_CSharp_ExposedLayoutC a, const MR_CSharp_ExposedLayoutC *b)
+{
+    return MRBINDC_BIT_CAST((MR_CSharp_ExposedLayoutC), ::MR::CSharp::test_exposed_c(
+        MRBINDC_BIT_CAST((MR::CSharp::ExposedLayoutC), a),
+        (b ? MRBINDC_BIT_CAST((MR::CSharp::ExposedLayoutC), *b) : MR::CSharp::ExposedLayoutC(MR::CSharp::ExposedLayoutC{}))
+    ));
+}
+
 const int *MR_CSharp_ArrayMembers_Get_i(const MR_CSharp_ArrayMembers *_this)
 {
     return std::addressof(((_this ? void() : MRBINDC_THROW("Parameter `_this` can not be null.", void)), *(const MR::CSharp::ArrayMembers *)(_this)).i);

--- a/test/output_csharp/src/MR/test_csharp.cs
+++ b/test/output_csharp/src/MR/test_csharp.cs
@@ -13697,10 +13697,9 @@ public static partial class MR
             // A converting ctor in an exposed struct.
             /// Generated from class `MR::CSharp::ConvCtorExposed`.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ConvCtorExposed
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// Copy contents from a wrapper class to this struct.
@@ -15836,10 +15835,9 @@ public static partial class MR
 
             /// Generated from class `MR::CSharp::ExposedLayoutB`.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ExposedLayoutB : System.IEquatable<MR.CS.CSharp.ExposedLayoutB>
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// Copy contents from a wrapper class to this struct.
@@ -16067,10 +16065,9 @@ public static partial class MR
             // Just a simple exposed struct to test other things.
             /// Generated from class `MR::CSharp::ExposedLayoutC`.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ExposedLayoutC
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// Copy contents from a wrapper class to this struct.
@@ -16967,10 +16964,9 @@ public static partial class MR
 
                 /// Generated from class `MR::CSharp::NameConflictsExposed::A`.
                 /// This is the by-value version of the struct.
-                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
                 public struct A
                 {
-                    [System.Runtime.InteropServices.FieldOffset(0)]
                     public int x;
 
                     /// Copy contents from a wrapper class to this struct.
@@ -17564,10 +17560,9 @@ public static partial class MR
             // Test that we don't produce the const and non-const overloads of the same function under the same name in C#, as that would be a compilation error in C#.
             /// Generated from class `MR::CSharp::ConstNonconstConflicts`.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ConstNonconstConflicts
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// Copy contents from a wrapper class to this struct.
@@ -25649,6 +25644,19 @@ public static partial class MR
                 var __c_ret = __MR_CSharp_test_exposed_cptr_const_MR_CSharp_ExposedLayoutSh_ptr(a.HasValue ? &__deref_a : null, b.HasValue ? &__deref_b : null, c is not null ? &__valueptr_c : null);
                 MR.CS.Misc._Exceptions.ThrowIfNeeded();
                 if (__c_ret is not null) return *__c_ret; else return null;
+            }
+
+            // Single-field exposed structs use `LayoutKind.Sequential` in C#. This tests passing and returning one by value.
+            /// Generated from function `MR::CSharp::test_exposed_c`.
+            /// Parameter `b` defaults to `{}`.
+            public static unsafe MR.CS.CSharp.ExposedLayoutC TestExposedC(MR.CS.CSharp.ExposedLayoutC a, MR.CS.CSharp._InOpt_ExposedLayoutC b = default)
+            {
+                [System.Runtime.InteropServices.DllImport("bleh", EntryPoint = "MR_CSharp_test_exposed_c", ExactSpelling = true)]
+                extern static MR.CS.CSharp.ExposedLayoutC __MR_CSharp_test_exposed_c(MR.CS.CSharp.ExposedLayoutC a, MR.CS.CSharp.ExposedLayoutC *b);
+                MR.CS.Misc._Exceptions.Prepare();
+                var __c_ret = __MR_CSharp_test_exposed_c(a, b.HasValue ? &b.Object : null);
+                MR.CS.Misc._Exceptions.ThrowIfNeeded();
+                return __c_ret;
             }
 
             /// Generated from function `MR::CSharp::test_optint`.

--- a/test/output_csharp/src/MR/test_declaration_order.cs
+++ b/test/output_csharp/src/MR/test_declaration_order.cs
@@ -108,10 +108,9 @@ public static partial class MR
             // Here all classes are whitelisted using `--expose-as-struct`.
             /// Generated from class `MR::DeclOrder::A`.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct A
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int blah;
 
                 /// Copy contents from a wrapper class to this struct.
@@ -249,10 +248,9 @@ public static partial class MR
 
                 /// Generated from class `MR::DeclOrder::A::B`.
                 /// This is the by-value version of the struct.
-                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
                 public struct B
                 {
-                    [System.Runtime.InteropServices.FieldOffset(0)]
                     public int bleh;
 
                     /// Copy contents from a wrapper class to this struct.
@@ -523,10 +521,9 @@ public static partial class MR
 
             /// Generated from class `MR::DeclOrder::C<false>`.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct C_False
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int bleh;
 
                 /// Copy contents from a wrapper class to this struct.
@@ -709,10 +706,9 @@ public static partial class MR
 
             /// Generated from class `MR::DeclOrder::C<true>`.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct C_True
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int bleh;
 
                 /// Copy contents from a wrapper class to this struct.

--- a/test/output_csharp/src/std_array_int_43.cs
+++ b/test/output_csharp/src/std_array_int_43.cs
@@ -83,10 +83,9 @@ public static partial class MR
 
             /// A fixed-size array of `int` of size 43.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 172)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct Array_Int_43
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public MR.CS.ArrayInt43 elems;
 
                 /// Copy contents from a wrapper class to this struct.

--- a/test/output_csharp/src/std_array_int_array_4_array_3_5.cs
+++ b/test/output_csharp/src/std_array_int_array_4_array_3_5.cs
@@ -83,10 +83,9 @@ public static partial class MR
 
             /// A fixed-size array of `int[3][4]` of size 5.
             /// This is the by-value version of the struct.
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 240)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct Array_IntArray4Array3_5
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public MR.CS.ArrayInt5_3_4 elems;
 
                 /// Copy contents from a wrapper class to this struct.

--- a/test/output_csharp_fixed_typedefs/src/MR/test_csharp.cs
+++ b/test/output_csharp_fixed_typedefs/src/MR/test_csharp.cs
@@ -14134,10 +14134,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ConvCtorExposed`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ConvCtorExposed
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -16413,10 +16412,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ExposedLayoutB`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ExposedLayoutB : System.IEquatable<MR.CS.CSharp.ExposedLayoutB>
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -16685,10 +16683,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ExposedLayoutC`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ExposedLayoutC
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -17694,10 +17691,9 @@ public static partial class MR
                 /// Generated from class `MR::CSharp::NameConflictsExposed::A`.
                 /// This is the by-value version of the struct.
                 /// </summary>
-                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
                 public struct A
                 {
-                    [System.Runtime.InteropServices.FieldOffset(0)]
                     public int x;
 
                     /// <summary>
@@ -18334,10 +18330,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ConstNonconstConflicts`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ConstNonconstConflicts
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -27131,6 +27126,18 @@ public static partial class MR
                 MR.CS.CSharp.ExposedLayoutSh *__valueptr_c = c is not null && c.Opt is not null ? &__value_c : null;
                 var __c_ret = __MR_CSharp_test_exposed_cptr_const_MR_CSharp_ExposedLayoutSh_ptr(a.HasValue ? &__deref_a : null, b.HasValue ? &__deref_b : null, c is not null ? &__valueptr_c : null);
                 if (__c_ret is not null) return *__c_ret; else return null;
+            }
+
+            // Single-field exposed structs use `LayoutKind.Sequential` in C#. This tests passing and returning one by value.
+            /// <summary>
+            /// Generated from function `MR::CSharp::test_exposed_c`.
+            /// Parameter `b` defaults to `{}`.
+            /// </summary>
+            public static unsafe MR.CS.CSharp.ExposedLayoutC testExposedC(MR.CS.CSharp.ExposedLayoutC a, MR.CS.CSharp._InOpt_ExposedLayoutC b = default)
+            {
+                [System.Runtime.InteropServices.DllImport("bleh", EntryPoint = "MR_CSharp_test_exposed_c", ExactSpelling = true)]
+                extern static MR.CS.CSharp.ExposedLayoutC __MR_CSharp_test_exposed_c(MR.CS.CSharp.ExposedLayoutC a, MR.CS.CSharp.ExposedLayoutC *b);
+                return __MR_CSharp_test_exposed_c(a, b.HasValue ? &b.Object : null);
             }
 
             /// <summary>

--- a/test/output_csharp_fixed_typedefs/src/MR/test_declaration_order.cs
+++ b/test/output_csharp_fixed_typedefs/src/MR/test_declaration_order.cs
@@ -132,10 +132,9 @@ public static partial class MR
             /// Generated from class `MR::DeclOrder::A`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct A
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int blah;
 
                 /// <summary>
@@ -299,10 +298,9 @@ public static partial class MR
                 /// Generated from class `MR::DeclOrder::A::B`.
                 /// This is the by-value version of the struct.
                 /// </summary>
-                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
                 public struct B
                 {
-                    [System.Runtime.InteropServices.FieldOffset(0)]
                     public int bleh;
 
                     /// <summary>
@@ -612,10 +610,9 @@ public static partial class MR
             /// Generated from class `MR::DeclOrder::C&lt;false&gt;`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct C_False
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int bleh;
 
                 /// <summary>
@@ -832,10 +829,9 @@ public static partial class MR
             /// Generated from class `MR::DeclOrder::C&lt;true&gt;`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct C_True
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int bleh;
 
                 /// <summary>

--- a/test/output_csharp_fixed_typedefs/src/std_array_int32_t_43.cs
+++ b/test/output_csharp_fixed_typedefs/src/std_array_int32_t_43.cs
@@ -109,10 +109,9 @@ public static partial class MR
             /// A fixed-size array of `int32_t` of size 43.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 172)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct Array_Int32T_43
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public MR.CS.ArrayInt32T43 elems;
 
                 /// <summary>

--- a/test/output_csharp_fixed_typedefs/src/std_array_int32_t_array_4_array_3_5.cs
+++ b/test/output_csharp_fixed_typedefs/src/std_array_int32_t_array_4_array_3_5.cs
@@ -109,10 +109,9 @@ public static partial class MR
             /// A fixed-size array of `int32_t[3][4]` of size 5.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 240)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct Array_Int32TArray4Array3_5
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public MR.CS.ArrayInt32T5_3_4 elems;
 
                 /// <summary>

--- a/test/output_csharp_fixed_typedefs_64_only/src/MR/test_csharp.cs
+++ b/test/output_csharp_fixed_typedefs_64_only/src/MR/test_csharp.cs
@@ -15282,10 +15282,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ConvCtorExposed`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ConvCtorExposed
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -17653,10 +17652,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ExposedLayoutB`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ExposedLayoutB : System.IEquatable<MR.CS.CSharp.ExposedLayoutB>
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -17925,10 +17923,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ExposedLayoutC`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ExposedLayoutC
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -18934,10 +18931,9 @@ public static partial class MR
                 /// Generated from class `MR::CSharp::NameConflictsExposed::A`.
                 /// This is the by-value version of the struct.
                 /// </summary>
-                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
                 public struct A
                 {
-                    [System.Runtime.InteropServices.FieldOffset(0)]
                     public int x;
 
                     /// <summary>
@@ -19574,10 +19570,9 @@ public static partial class MR
             /// Generated from class `MR::CSharp::ConstNonconstConflicts`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct ConstNonconstConflicts
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int x;
 
                 /// <summary>
@@ -28356,6 +28351,18 @@ public static partial class MR
                 MR.CS.CSharp.ExposedLayoutSh *__valueptr_c = c is not null && c.Opt is not null ? &__value_c : null;
                 var __c_ret = __MR_CSharp_test_exposed_cptr_const_MR_CSharp_ExposedLayoutSh_ptr(a.HasValue ? &__deref_a : null, b.HasValue ? &__deref_b : null, c is not null ? &__valueptr_c : null);
                 if (__c_ret is not null) return *__c_ret; else return null;
+            }
+
+            // Single-field exposed structs use `LayoutKind.Sequential` in C#. This tests passing and returning one by value.
+            /// <summary>
+            /// Generated from function `MR::CSharp::test_exposed_c`.
+            /// Parameter `b` defaults to `{}`.
+            /// </summary>
+            public static unsafe MR.CS.CSharp.ExposedLayoutC testExposedC(MR.CS.CSharp.ExposedLayoutC a, MR.CS.CSharp._InOpt_ExposedLayoutC b = default)
+            {
+                [System.Runtime.InteropServices.DllImport("bleh", EntryPoint = "MR_CSharp_test_exposed_c", ExactSpelling = true)]
+                extern static MR.CS.CSharp.ExposedLayoutC __MR_CSharp_test_exposed_c(MR.CS.CSharp.ExposedLayoutC a, MR.CS.CSharp.ExposedLayoutC *b);
+                return __MR_CSharp_test_exposed_c(a, b.HasValue ? &b.Object : null);
             }
 
             /// <summary>

--- a/test/output_csharp_fixed_typedefs_64_only/src/MR/test_declaration_order.cs
+++ b/test/output_csharp_fixed_typedefs_64_only/src/MR/test_declaration_order.cs
@@ -132,10 +132,9 @@ public static partial class MR
             /// Generated from class `MR::DeclOrder::A`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct A
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int blah;
 
                 /// <summary>
@@ -299,10 +298,9 @@ public static partial class MR
                 /// Generated from class `MR::DeclOrder::A::B`.
                 /// This is the by-value version of the struct.
                 /// </summary>
-                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+                [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
                 public struct B
                 {
-                    [System.Runtime.InteropServices.FieldOffset(0)]
                     public int bleh;
 
                     /// <summary>
@@ -612,10 +610,9 @@ public static partial class MR
             /// Generated from class `MR::DeclOrder::C&lt;false&gt;`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct C_False
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int bleh;
 
                 /// <summary>
@@ -832,10 +829,9 @@ public static partial class MR
             /// Generated from class `MR::DeclOrder::C&lt;true&gt;`.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 4)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct C_True
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public int bleh;
 
                 /// <summary>

--- a/test/output_csharp_fixed_typedefs_64_only/src/std_array_int_43.cs
+++ b/test/output_csharp_fixed_typedefs_64_only/src/std_array_int_43.cs
@@ -109,10 +109,9 @@ public static partial class MR
             /// A fixed-size array of `int` of size 43.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 172)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct Array_Int_43
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public MR.CS.ArrayInt43 elems;
 
                 /// <summary>

--- a/test/output_csharp_fixed_typedefs_64_only/src/std_array_int_array_4_array_3_5.cs
+++ b/test/output_csharp_fixed_typedefs_64_only/src/std_array_int_array_4_array_3_5.cs
@@ -109,10 +109,9 @@ public static partial class MR
             /// A fixed-size array of `int[3][4]` of size 5.
             /// This is the by-value version of the struct.
             /// </summary>
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit, Size = 240)]
+            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
             public struct Array_IntArray4Array3_5
             {
-                [System.Runtime.InteropServices.FieldOffset(0)]
                 public MR.CS.ArrayInt5_3_4 elems;
 
                 /// <summary>


### PR DESCRIPTION
## Problem

Unity WebGL (IL2CPP) builds of MeshLib's wasm bindings link with 622 `wasm-ld: warning: function signature mismatch`, one per C API function returning an `MR::*Id`; those calls trap at runtime. The ~1000 functions that take an Id *by value* get no warning (same `i32` on both sides) but silently receive a pointer to a stack copy instead of the value.

Root cause: exposed structs are emitted with `LayoutKind.Explicit` + `FieldOffset`. IL2CPP compiles explicit-layout structs to a union with padding (`union { struct { ... }; uint8_t padding[N]; }`), and Clang's wasm32 ABI only flattens *single-element* structs to scalars. So a one-field struct becomes an aggregate on the IL2CPP side (returned through a hidden pointer, passed by pointer) while the C side uses a plain `int`. IL2CPP compiles *sequential* structs to plain C structs (e.g. `struct Int32_t { int32_t ___m_value; };`), which Clang flattens exactly like the C side. Multi-field structs are passed indirectly on both sides and are unaffected.

## Fix

Exposed structs with exactly one non-static field are emitted with `LayoutKind.Sequential` and without `FieldOffset` attributes. For one field both layouts are trivially identical (offset 0, size and alignment of the field), so nothing else changes: no `DllImport` signatures, no C API. All other exposed structs keep `LayoutKind.Explicit`.

## Verification

- Regenerated all test outputs (parser built with gcc 14 + the `llvm-22.1.8` libs, like CI). The diff is confined to the attribute lines of the single-field structs (`ConvCtorExposed`, `ExposedLayoutB`, `ExposedLayoutC`, `ConstNonconstConflicts`, `NameConflictsExposed::A`, `DeclOrder::*`, and the `std::array` wrappers) plus the new test function.
- `dotnet build` of the three generated C# test projects: 0 warnings.
- The ABI difference was reproduced with Unity's own emcc: IL2CPP's union shape gives `(i32 sret) -> void` and pass-by-pointer; the plain one-field struct gives `() -> i32` and pass-by-value, matching MeshLib's C API.
- Added `test_exposed_c()` covering a by-value parameter and return value of a single-field exposed struct.

Supersedes #48, which fixed the same bug at the `DllImport` level with more code.

Follow-up in MeshLib: bump mrbind and regenerate the C# bindings; the Unity wasm link should then be free of `function signature mismatch` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
